### PR TITLE
Refactor spclient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 bitcoin = { version = "0.31.1", features = ["serde", "rand", "base64"] }
 rayon = "1.10.0"
+futures = "0.3"
+log = "0.4"
+async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,8 @@ rayon = "1.10.0"
 futures = "0.3"
 log = "0.4"
 async-trait = "0.1"
+reqwest = { version = "0.12.4", features = ["rustls-tls"], default-features = false, optional = true }
+hex = { version = "0.4.3", features = ["serde"], optional = true }
+
+[features]
+blindbit-backend = ["reqwest", "hex"]

--- a/src/backend/backend.rs
+++ b/src/backend/backend.rs
@@ -1,0 +1,23 @@
+use std::{ops::RangeInclusive, pin::Pin};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use bitcoin::{absolute::Height, Amount};
+use futures::Stream;
+
+use super::structs::{BlockData, SpentIndexData, UtxoData};
+
+#[async_trait]
+pub trait ChainBackend {
+    fn get_block_data_for_range(
+        &self,
+        range: RangeInclusive<u32>,
+        dust_limit: Amount,
+    ) -> Pin<Box<dyn Stream<Item = Result<BlockData>> + Send>>;
+
+    async fn spent_index(&self, block_height: Height) -> Result<SpentIndexData>;
+
+    async fn utxos(&self, block_height: Height) -> Result<Vec<UtxoData>>;
+
+    async fn block_height(&self) -> Result<Height>;
+}

--- a/src/backend/blindbit/backend/backend.rs
+++ b/src/backend/blindbit/backend/backend.rs
@@ -1,0 +1,81 @@
+use std::{ops::RangeInclusive, pin::Pin, sync::Arc};
+
+use async_trait::async_trait;
+use bitcoin::{absolute::Height, Amount};
+use futures::{stream, Stream, StreamExt};
+use reqwest::Url;
+
+use anyhow::Result;
+
+use crate::{backend::blindbit::BlindbitClient, BlockData, ChainBackend, SpentIndexData, UtxoData};
+
+const CONCURRENT_FILTER_REQUESTS: usize = 200;
+
+pub struct BlindbitBackend {
+    client: BlindbitClient,
+}
+
+impl BlindbitBackend {
+    pub fn new(blindbit_url: String) -> Result<Self> {
+        let host_url = Url::parse(&blindbit_url)?;
+        Ok(Self {
+            client: BlindbitClient::new(host_url),
+        })
+    }
+}
+
+#[async_trait]
+impl ChainBackend for BlindbitBackend {
+    /// High-level function to get block data for a range of blocks.
+    /// Block data includes all the information needed to determine if a block is relevant for scanning,
+    /// but does not include utxos, or spent index.
+    /// These need to be fetched separately afterwards, if it is determined this block is relevant.
+    fn get_block_data_for_range(
+        &self,
+        range: RangeInclusive<u32>,
+        dust_limit: Amount,
+    ) -> Pin<Box<dyn Stream<Item = Result<BlockData>> + Send>> {
+        let client = Arc::new(self.client.clone());
+
+        let res = stream::iter(range)
+            .map(move |n| {
+                let client = client.clone();
+
+                async move {
+                    let blkheight = Height::from_consensus(n)?;
+                    let tweaks = client.tweak_index(blkheight, dust_limit).await?;
+                    let new_utxo_filter = client.filter_new_utxos(blkheight).await?;
+                    let spent_filter = client.filter_spent(blkheight).await?;
+                    let blkhash = new_utxo_filter.block_hash;
+                    Ok(BlockData {
+                        blkheight,
+                        blkhash,
+                        tweaks,
+                        new_utxo_filter: new_utxo_filter.into(),
+                        spent_filter: spent_filter.into(),
+                    })
+                }
+            })
+            .buffered(CONCURRENT_FILTER_REQUESTS);
+
+        Box::pin(res)
+    }
+
+    async fn spent_index(&self, block_height: Height) -> Result<SpentIndexData> {
+        self.client.spent_index(block_height).await.map(Into::into)
+    }
+
+    async fn utxos(&self, block_height: Height) -> Result<Vec<UtxoData>> {
+        Ok(self
+            .client
+            .utxos(block_height)
+            .await?
+            .into_iter()
+            .map(Into::into)
+            .collect())
+    }
+
+    async fn block_height(&self) -> Result<Height> {
+        self.client.block_height().await
+    }
+}

--- a/src/backend/blindbit/backend/mod.rs
+++ b/src/backend/blindbit/backend/mod.rs
@@ -1,0 +1,3 @@
+mod backend;
+
+pub use backend::BlindbitBackend;

--- a/src/backend/blindbit/client/client.rs
+++ b/src/backend/blindbit/client/client.rs
@@ -1,0 +1,106 @@
+use std::time::Duration;
+
+use bitcoin::{absolute::Height, secp256k1::PublicKey, Amount};
+use reqwest::{Client, Url};
+
+use anyhow::Result;
+
+use super::structs::{BlockHeightResponse, FilterResponse, SpentIndexResponse, UtxoResponse};
+
+#[derive(Clone)]
+pub struct BlindbitClient {
+    client: Client,
+    host_url: Url,
+}
+
+impl BlindbitClient {
+    pub fn new(mut host_url: Url) -> Self {
+        let client = reqwest::Client::new();
+
+        // we need a trailing slash, if not present we append it
+        if !host_url.path().ends_with('/') {
+            host_url.set_path(&format!("{}/", host_url.path()));
+        }
+
+        BlindbitClient { client, host_url }
+    }
+    pub async fn block_height(&self) -> Result<Height> {
+        let url = self.host_url.join("block-height")?;
+
+        let res = self
+            .client
+            .get(url)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await?;
+        let blkheight: BlockHeightResponse = serde_json::from_str(&res.text().await?)?;
+        Ok(blkheight.block_height)
+    }
+
+    #[allow(dead_code)]
+    pub async fn tweaks(&self, block_height: Height) -> Result<Vec<PublicKey>> {
+        let url = self.host_url.join(&format!("tweaks/{}", block_height))?;
+
+        let res = self.client.get(url).send().await?;
+        Ok(serde_json::from_str(&res.text().await?)?)
+    }
+
+    pub async fn tweak_index(
+        &self,
+        block_height: Height,
+        dust_limit: Amount,
+    ) -> Result<Vec<PublicKey>> {
+        let url = self
+            .host_url
+            .join(&format!("tweak-index/{}", block_height))?;
+
+        let res = self
+            .client
+            .get(url)
+            .query(&[("dustLimit", format!("{}", dust_limit.to_sat()))])
+            .send()
+            .await?;
+        Ok(serde_json::from_str(&res.text().await?)?)
+    }
+
+    pub async fn utxos(&self, block_height: Height) -> Result<Vec<UtxoResponse>> {
+        let url = self.host_url.join(&format!("utxos/{}", block_height))?;
+        let res = self.client.get(url).send().await?;
+
+        Ok(serde_json::from_str(&res.text().await?)?)
+    }
+
+    pub async fn spent_index(&self, block_height: Height) -> Result<SpentIndexResponse> {
+        let url = self
+            .host_url
+            .join(&format!("spent-index/{}", block_height))?;
+        let res = self.client.get(url).send().await?;
+
+        Ok(serde_json::from_str(&res.text().await?)?)
+    }
+
+    pub async fn filter_new_utxos(&self, block_height: Height) -> Result<FilterResponse> {
+        let url = self
+            .host_url
+            .join(&format!("filter/new-utxos/{}", block_height))?;
+
+        let res = self.client.get(url).send().await?;
+
+        Ok(serde_json::from_str(&res.text().await?)?)
+    }
+
+    pub async fn filter_spent(&self, block_height: Height) -> Result<FilterResponse> {
+        let url = self
+            .host_url
+            .join(&format!("filter/spent/{}", block_height))?;
+
+        let res = self.client.get(url).send().await?;
+
+        Ok(serde_json::from_str(&res.text().await?)?)
+    }
+
+    #[allow(dead_code)]
+    pub async fn forward_tx(&self) {
+        // not needed
+    }
+}

--- a/src/backend/blindbit/client/mod.rs
+++ b/src/backend/blindbit/client/mod.rs
@@ -1,0 +1,4 @@
+mod client;
+pub mod structs;
+
+pub use client::BlindbitClient;

--- a/src/backend/blindbit/client/structs.rs
+++ b/src/backend/blindbit/client/structs.rs
@@ -1,0 +1,71 @@
+use bitcoin::{absolute::Height, Amount, BlockHash, ScriptBuf, Txid};
+use serde::Deserialize;
+
+use crate::{FilterData, SpentIndexData, UtxoData};
+
+#[derive(Debug, Deserialize)]
+pub struct BlockHeightResponse {
+    pub block_height: Height,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UtxoResponse {
+    pub txid: Txid,
+    pub vout: u32,
+    pub value: Amount,
+    pub scriptpubkey: ScriptBuf,
+    pub block_height: Height,
+    pub block_hash: BlockHash,
+    pub timestamp: i32,
+    pub spent: bool,
+}
+
+impl From<UtxoResponse> for UtxoData {
+    fn from(value: UtxoResponse) -> Self {
+        Self {
+            txid: value.txid,
+            vout: value.vout,
+            value: value.value,
+            scriptpubkey: value.scriptpubkey,
+            spent: value.spent,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SpentIndexResponse {
+    pub block_hash: BlockHash,
+    pub data: Vec<MyHex>,
+}
+
+impl From<SpentIndexResponse> for SpentIndexData {
+    fn from(value: SpentIndexResponse) -> Self {
+        Self {
+            data: value.data.into_iter().map(|x| x.hex).collect(),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(transparent)]
+pub struct MyHex {
+    #[serde(with = "hex::serde")]
+    pub hex: Vec<u8>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FilterResponse {
+    pub block_hash: BlockHash,
+    pub block_height: Height,
+    pub data: MyHex,
+    pub filter_type: i32,
+}
+
+impl From<FilterResponse> for FilterData {
+    fn from(value: FilterResponse) -> Self {
+        Self {
+            block_hash: value.block_hash,
+            data: value.data.hex,
+        }
+    }
+}

--- a/src/backend/blindbit/mod.rs
+++ b/src/backend/blindbit/mod.rs
@@ -1,0 +1,5 @@
+mod backend;
+mod client;
+
+pub use backend::BlindbitBackend;
+pub use client::BlindbitClient;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,0 +1,5 @@
+mod backend;
+mod structs;
+
+pub use backend::ChainBackend;
+pub use structs::*;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,5 +1,10 @@
 mod backend;
+#[cfg(feature = "blindbit-backend")]
+mod blindbit;
 mod structs;
 
 pub use backend::ChainBackend;
 pub use structs::*;
+
+#[cfg(feature = "blindbit-backend")]
+pub use blindbit::BlindbitBackend;

--- a/src/backend/structs.rs
+++ b/src/backend/structs.rs
@@ -1,0 +1,26 @@
+use bitcoin::{absolute::Height, secp256k1::PublicKey, Amount, BlockHash, ScriptBuf, Txid};
+
+pub struct BlockData {
+    pub blkheight: Height,
+    pub blkhash: BlockHash,
+    pub tweaks: Vec<PublicKey>,
+    pub new_utxo_filter: FilterData,
+    pub spent_filter: FilterData,
+}
+
+pub struct UtxoData {
+    pub txid: Txid,
+    pub vout: u32,
+    pub value: Amount,
+    pub scriptpubkey: ScriptBuf,
+    pub spent: bool,
+}
+
+pub struct SpentIndexData {
+    pub data: Vec<Vec<u8>>,
+}
+
+pub struct FilterData {
+    pub block_hash: BlockHash,
+    pub data: Vec<u8>,
+}

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use bitcoin::{
-    absolute::Height,
     consensus::{deserialize, serialize},
     key::{constants::ONE, TapTweak},
     psbt::PsbtSighashType,
@@ -38,59 +37,7 @@ use crate::constants::{
 
 pub use bitcoin::psbt::Psbt;
 
-type SpendingTxId = String;
-type MinedInBlock = String;
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub enum OutputSpendStatus {
-    Unspent,
-    Spent(SpendingTxId),
-    Mined(MinedInBlock),
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct OwnedOutput {
-    pub blockheight: Height,
-    pub tweak: [u8; 32], // scalar in big endian format
-    pub amount: Amount,
-    pub script: ScriptBuf,
-    pub label: Option<String>,
-    pub spend_status: OutputSpendStatus,
-}
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct Recipient {
-    pub address: String, // either old school or silent payment
-    pub amount: Amount,
-    pub nb_outputs: u32, // if address is not SP, only 1 is valid
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-pub enum SpendKey {
-    Secret(SecretKey),
-    Public(PublicKey),
-}
-
-impl TryInto<SecretKey> for SpendKey {
-    type Error = anyhow::Error;
-    fn try_into(self) -> std::prelude::v1::Result<SecretKey, Error> {
-        match self {
-            Self::Secret(k) => Ok(k),
-            Self::Public(_) => Err(Error::msg("Can't take SecretKey from Public")),
-        }
-    }
-}
-
-impl Into<PublicKey> for SpendKey {
-    fn into(self) -> PublicKey {
-        match self {
-            Self::Secret(k) => {
-                let secp = Secp256k1::signing_only();
-                k.public_key(&secp)
-            }
-            Self::Public(p) => p,
-        }
-    }
-}
+use super::{OwnedOutput, Recipient, SpendKey};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct SpClient {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,0 +1,5 @@
+mod client;
+mod structs;
+
+pub use client::SpClient;
+pub use structs::*;

--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -1,0 +1,58 @@
+use anyhow::Error;
+use bitcoin::{absolute::Height, key::Secp256k1, secp256k1::{PublicKey, SecretKey}, Amount, ScriptBuf};
+use serde::{Deserialize, Serialize};
+
+type SpendingTxId = String;
+type MinedInBlock = String;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub enum OutputSpendStatus {
+    Unspent,
+    Spent(SpendingTxId),
+    Mined(MinedInBlock),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct OwnedOutput {
+    pub blockheight: Height,
+    pub tweak: [u8; 32], // scalar in big endian format
+    pub amount: Amount,
+    pub script: ScriptBuf,
+    pub label: Option<String>,
+    pub spend_status: OutputSpendStatus,
+}
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct Recipient {
+    pub address: String, // either old school or silent payment
+    pub amount: Amount,
+    pub nb_outputs: u32, // if address is not SP, only 1 is valid
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub enum SpendKey {
+    Secret(SecretKey),
+    Public(PublicKey),
+}
+
+impl TryInto<SecretKey> for SpendKey {
+    type Error = anyhow::Error;
+    fn try_into(self) -> std::prelude::v1::Result<SecretKey, Error> {
+        match self {
+            Self::Secret(k) => Ok(k),
+            Self::Public(_) => Err(Error::msg("Can't take SecretKey from Public")),
+        }
+    }
+}
+
+impl Into<PublicKey> for SpendKey {
+    fn into(self) -> PublicKey {
+        match self {
+            Self::Secret(k) => {
+                let secp = Secp256k1::signing_only();
+                k.public_key(&secp)
+            }
+            Self::Public(p) => p,
+        }
+    }
+}
+

--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -1,5 +1,10 @@
 use anyhow::Error;
-use bitcoin::{absolute::Height, key::Secp256k1, secp256k1::{PublicKey, SecretKey}, Amount, ScriptBuf};
+use bitcoin::{
+    absolute::Height,
+    key::Secp256k1,
+    secp256k1::{PublicKey, SecretKey},
+    Amount, ScriptBuf,
+};
 use serde::{Deserialize, Serialize};
 
 type SpendingTxId = String;
@@ -55,4 +60,3 @@ impl Into<PublicKey> for SpendKey {
         }
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
-pub mod constants;
-mod client;
-mod scanner;
 mod backend;
+mod client;
+pub mod constants;
+mod scanner;
 mod updater;
 
 pub use bitcoin;
 pub use silentpayments;
 
-pub use backend::ChainBackend;
+pub use backend::*;
+pub use client::*;
 pub use scanner::SpScanner;
 pub use updater::Updater;
-pub use client::SpClient;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,13 @@
 pub mod constants;
-pub mod spclient;
+mod client;
+mod scanner;
+mod backend;
+mod updater;
 
 pub use bitcoin;
 pub use silentpayments;
+
+pub use backend::ChainBackend;
+pub use scanner::SpScanner;
+pub use updater::Updater;
+pub use client::SpClient;

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -1,0 +1,3 @@
+mod scanner;
+
+pub use scanner::SpScanner;

--- a/src/scanner/scanner.rs
+++ b/src/scanner/scanner.rs
@@ -1,0 +1,359 @@
+use std::{
+    collections::{HashMap, HashSet},
+    time::{Duration, Instant},
+};
+
+use anyhow::{bail, Error, Result};
+use bitcoin::{
+    absolute::Height,
+    bip158::BlockFilter,
+    hashes::{sha256, Hash},
+    secp256k1::{PublicKey, Scalar},
+    Amount, BlockHash, OutPoint, Txid, XOnlyPublicKey,
+};
+use futures::{pin_mut, Stream, StreamExt};
+use log::info;
+use silentpayments::receiving::Label;
+
+use crate::{
+    backend::{BlockData, ChainBackend, FilterData, UtxoData},
+    client::{OutputSpendStatus, OwnedOutput, SpClient}, updater::Updater,
+};
+
+pub struct SpScanner {
+    updater: Box<dyn Updater + Sync + Send>,
+    backend: Box<dyn ChainBackend + Sync + Send>,
+    client: SpClient,
+    owned_outpoints: HashSet<OutPoint>, // used to scan block inputs
+}
+
+impl SpScanner {
+    pub fn new(
+        client: SpClient,
+        updater: Box<dyn Updater + Sync + Send>,
+        backend: Box<dyn ChainBackend + Sync + Send>,
+        owned_outpoints: HashSet<OutPoint>,
+    ) -> Self {
+        Self {
+            client,
+            updater,
+            backend,
+            owned_outpoints,
+        }
+    }
+
+    pub async fn scan_blocks(
+        &mut self,
+        start: Height,
+        end: Height,
+        dust_limit: Amount,
+    ) -> Result<()> {
+        if start > end {
+            bail!("bigger start than end: {} > {}", start, end);
+        }
+
+        info!("start: {} end: {}", start, end);
+        let start_time: Instant = Instant::now();
+
+        // get block data stream
+        let range = start.to_consensus_u32()..=end.to_consensus_u32();
+        let block_data_stream = self.backend.get_block_data_for_range(range, dust_limit);
+
+        // process blocks using block data stream
+        self.process_blocks(block_data_stream).await?;
+
+        // after processing, always send update
+        self.updater.update_last_scan(end);
+
+        // time elapsed for the scan
+        info!(
+            "Blindbit scan complete in {} seconds",
+            start_time.elapsed().as_secs()
+        );
+
+        Ok(())
+    }
+
+    async fn process_blocks(
+        &mut self,
+        block_data_stream: impl Stream<Item = Result<BlockData>>,
+    ) -> Result<()> {
+        pin_mut!(block_data_stream);
+
+        let mut update_time: Instant = Instant::now();
+
+        while let Some(blockdata) = block_data_stream.next().await {
+            let blockdata = blockdata?;
+            let blkheight = blockdata.blkheight;
+            let blkhash = blockdata.blkhash;
+
+            self.updater.send_scan_progress(blkheight);
+
+            let mut send_update = false;
+
+            // send update after 30 seconds since last update
+            if update_time.elapsed() > Duration::from_secs(30) {
+                send_update = true;
+                update_time = Instant::now();
+            }
+
+            let (found_outputs, found_inputs) = self.process_block(blockdata).await?;
+
+            if !found_outputs.is_empty() {
+                send_update = true;
+                self.updater.record_block_outputs(blkheight, found_outputs);
+            }
+
+            if !found_inputs.is_empty() {
+                send_update = true;
+                self.updater
+                    .record_block_inputs(blkheight, blkhash, found_inputs)?;
+            }
+
+            if send_update {
+                self.updater.update_last_scan(blkheight);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn process_block(
+        &mut self,
+        blockdata: BlockData,
+    ) -> Result<(HashMap<OutPoint, OwnedOutput>, HashSet<OutPoint>)> {
+        let BlockData {
+            blkheight,
+            tweaks,
+            new_utxo_filter,
+            spent_filter,
+            ..
+        } = blockdata;
+
+        let outs = self
+            .process_block_outputs(blkheight, tweaks, new_utxo_filter)
+            .await?;
+
+        // after processing outputs, we add the found outputs to our list
+        self.owned_outpoints.extend(outs.keys());
+
+        let ins = self.process_block_inputs(blkheight, spent_filter).await?;
+
+        // after processing inputs, we remove the found inputs
+        self.owned_outpoints.retain(|item| !ins.contains(item));
+
+        Ok((outs, ins))
+    }
+
+    async fn process_block_outputs(
+        &self,
+        blkheight: Height,
+        tweaks: Vec<PublicKey>,
+        new_utxo_filter: FilterData,
+    ) -> Result<HashMap<OutPoint, OwnedOutput>> {
+        let mut res = HashMap::new();
+
+        if !tweaks.is_empty() {
+            let secrets_map = self.client.get_script_to_secret_map(tweaks)?;
+
+            //last_scan = last_scan.max(n as u32);
+            let candidate_spks: Vec<&[u8; 34]> = secrets_map.keys().collect();
+
+            //get block gcs & check match
+            let blkfilter = BlockFilter::new(&new_utxo_filter.data);
+            let blkhash = new_utxo_filter.block_hash;
+
+            let matched_outputs = Self::check_block_outputs(blkfilter, blkhash, candidate_spks)?;
+
+            //if match: fetch and scan utxos
+            if matched_outputs {
+                info!("matched outputs on: {}", blkheight);
+                let found = self.scan_utxos(blkheight, secrets_map).await?;
+
+                if !found.is_empty() {
+                    for (label, utxo, tweak) in found {
+                        let outpoint = OutPoint {
+                            txid: utxo.txid,
+                            vout: utxo.vout,
+                        };
+
+                        let out = OwnedOutput {
+                            blockheight: blkheight,
+                            tweak: tweak.to_be_bytes(),
+                            amount: utxo.value,
+                            script: utxo.scriptpubkey,
+                            label: label.map(|l| l.as_string()),
+                            spend_status: OutputSpendStatus::Unspent,
+                        };
+
+                        res.insert(outpoint, out);
+                    }
+                }
+            }
+        }
+        Ok(res)
+    }
+
+    async fn process_block_inputs(
+        &self,
+        blkheight: Height,
+        spent_filter: FilterData,
+    ) -> Result<HashSet<OutPoint>> {
+        let mut res = HashSet::new();
+
+        let blkhash = spent_filter.block_hash;
+
+        // first get the 8-byte hashes used to construct the input filter
+        let input_hashes_map = self.get_input_hashes(blkhash)?;
+
+        // check against filter
+        let blkfilter = BlockFilter::new(&spent_filter.data);
+        let matched_inputs = self.check_block_inputs(
+            blkfilter,
+            blkhash,
+            input_hashes_map.keys().cloned().collect(),
+        )?;
+
+        // if match: download spent data, collect the outpoints that are spent
+        if matched_inputs {
+            info!("matched inputs on: {}", blkheight);
+            let spent = self.backend.spent_index(blkheight).await?.data;
+
+            for spent in spent {
+                let hex: &[u8] = spent.as_ref();
+
+                if let Some(outpoint) = input_hashes_map.get(hex) {
+                    res.insert(*outpoint);
+                }
+            }
+        }
+        Ok(res)
+    }
+
+    async fn scan_utxos(
+        &self,
+        blkheight: Height,
+        secrets_map: HashMap<[u8; 34], PublicKey>,
+    ) -> Result<Vec<(Option<Label>, UtxoData, Scalar)>> {
+        let utxos = self.backend.utxos(blkheight).await?;
+
+        let mut res: Vec<(Option<Label>, UtxoData, Scalar)> = vec![];
+
+        // group utxos by the txid
+        let mut txmap: HashMap<Txid, Vec<UtxoData>> = HashMap::new();
+        for utxo in utxos {
+            txmap.entry(utxo.txid).or_default().push(utxo);
+        }
+
+        for utxos in txmap.into_values() {
+            // check if we know the secret to any of the spks
+            let mut secret = None;
+            for utxo in utxos.iter() {
+                let spk = utxo.scriptpubkey.as_bytes();
+                if let Some(s) = secrets_map.get(spk) {
+                    secret = Some(s);
+                    break;
+                }
+            }
+
+            // skip this tx if no secret is found
+            let secret = match secret {
+                Some(secret) => secret,
+                None => continue,
+            };
+
+            let output_keys: Result<Vec<XOnlyPublicKey>> = utxos
+                .iter()
+                .filter_map(|x| {
+                    if x.scriptpubkey.is_p2tr() {
+                        Some(
+                            XOnlyPublicKey::from_slice(&x.scriptpubkey.as_bytes()[2..])
+                                .map_err(Error::new),
+                        )
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            let ours = self
+                .client
+                .sp_receiver
+                .scan_transaction(secret, output_keys?)?;
+
+            for utxo in utxos {
+                if !utxo.scriptpubkey.is_p2tr() || utxo.spent {
+                    continue;
+                }
+
+                match XOnlyPublicKey::from_slice(&utxo.scriptpubkey.as_bytes()[2..]) {
+                    Ok(xonly) => {
+                        for (label, map) in ours.iter() {
+                            if let Some(scalar) = map.get(&xonly) {
+                                res.push((label.clone(), utxo, scalar.clone()));
+                                break;
+                            }
+                        }
+                    }
+                    Err(_) => todo!(),
+                }
+            }
+        }
+
+        Ok(res)
+    }
+
+    // Check if this block contains relevant transactions
+    fn check_block_outputs(
+        created_utxo_filter: BlockFilter,
+        blkhash: BlockHash,
+        candidate_spks: Vec<&[u8; 34]>,
+    ) -> Result<bool> {
+        // check output scripts
+        let output_keys: Vec<_> = candidate_spks
+            .into_iter()
+            .map(|spk| spk[2..].as_ref())
+            .collect();
+
+        // note: match will always return true for an empty query!
+        if !output_keys.is_empty() {
+            Ok(created_utxo_filter.match_any(&blkhash, &mut output_keys.into_iter())?)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn get_input_hashes(&self, blkhash: BlockHash) -> Result<HashMap<[u8; 8], OutPoint>> {
+        let mut map: HashMap<[u8; 8], OutPoint> = HashMap::new();
+
+        for outpoint in &self.owned_outpoints {
+            let mut arr = [0u8; 68];
+            arr[..32].copy_from_slice(&outpoint.txid.to_raw_hash().to_byte_array());
+            arr[32..36].copy_from_slice(&outpoint.vout.to_le_bytes());
+            arr[36..].copy_from_slice(&blkhash.to_byte_array());
+            let hash = sha256::Hash::hash(&arr);
+
+            let mut res = [0u8; 8];
+            res.copy_from_slice(&hash[..8]);
+
+            map.insert(res, outpoint.clone());
+        }
+
+        Ok(map)
+    }
+
+    // Check if this block contains relevant transactions
+    fn check_block_inputs(
+        &self,
+        spent_filter: BlockFilter,
+        blkhash: BlockHash,
+        input_hashes: Vec<[u8; 8]>,
+    ) -> Result<bool> {
+        // note: match will always return true for an empty query!
+        if !input_hashes.is_empty() {
+            Ok(spent_filter.match_any(&blkhash, &mut input_hashes.into_iter())?)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/src/scanner/scanner.rs
+++ b/src/scanner/scanner.rs
@@ -17,7 +17,8 @@ use silentpayments::receiving::Label;
 
 use crate::{
     backend::{BlockData, ChainBackend, FilterData, UtxoData},
-    client::{OutputSpendStatus, OwnedOutput, SpClient}, updater::Updater,
+    client::{OutputSpendStatus, OwnedOutput, SpClient},
+    updater::Updater,
 };
 
 pub struct SpScanner {

--- a/src/spclient.rs
+++ b/src/spclient.rs
@@ -94,10 +94,8 @@ impl Into<PublicKey> for SpendKey {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct SpClient {
-    pub label: String,
     scan_sk: SecretKey,
     spend_key: SpendKey,
-    mnemonic: Option<String>,
     pub sp_receiver: Receiver,
     network: Network,
 }
@@ -109,10 +107,8 @@ impl Default for SpClient {
             .unwrap()
             .public_key(bitcoin::key::Parity::Even);
         Self {
-            label: "default".to_owned(),
             scan_sk: default_sk,
             spend_key: SpendKey::Secret(default_sk),
-            mnemonic: None,
             sp_receiver: Receiver::new(
                 0,
                 default_pubkey,
@@ -127,13 +123,7 @@ impl Default for SpClient {
 }
 
 impl SpClient {
-    pub fn new(
-        label: String,
-        scan_sk: SecretKey,
-        spend_key: SpendKey,
-        mnemonic: Option<String>,
-        network: Network,
-    ) -> Result<Self> {
+    pub fn new(scan_sk: SecretKey, spend_key: SpendKey, network: Network) -> Result<Self> {
         let secp = Secp256k1::signing_only();
         let scan_pubkey = scan_sk.public_key(&secp);
         let sp_receiver: Receiver;
@@ -162,10 +152,8 @@ impl SpClient {
         }
 
         Ok(Self {
-            label,
             scan_sk,
             spend_key,
-            mnemonic,
             sp_receiver,
             network,
         })
@@ -181,10 +169,6 @@ impl SpClient {
 
     pub fn get_spend_key(&self) -> SpendKey {
         self.spend_key.clone()
-    }
-
-    pub fn get_mnemonic(&self) -> Option<String> {
-        self.mnemonic.clone()
     }
 
     pub fn get_network(&self) -> Network {

--- a/src/updater/mod.rs
+++ b/src/updater/mod.rs
@@ -1,0 +1,3 @@
+mod updater;
+
+pub use updater::Updater;

--- a/src/updater/updater.rs
+++ b/src/updater/updater.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 
 use crate::client::OwnedOutput;
 
-
 pub trait Updater {
     fn update_last_scan(&mut self, height: Height);
 

--- a/src/updater/updater.rs
+++ b/src/updater/updater.rs
@@ -1,0 +1,30 @@
+use std::collections::{HashMap, HashSet};
+
+use bitcoin::{absolute::Height, BlockHash, OutPoint};
+
+use anyhow::Result;
+
+use crate::client::OwnedOutput;
+
+
+pub trait Updater {
+    fn update_last_scan(&mut self, height: Height);
+
+    fn send_scan_progress(&self, current: Height);
+
+    fn record_block_outputs(
+        &mut self,
+        height: Height,
+        found_outputs: HashMap<OutPoint, OwnedOutput>,
+    );
+    fn record_block_inputs(
+        &mut self,
+        blkheight: Height,
+        blkhash: BlockHash,
+        found_inputs: HashSet<OutPoint>,
+    ) -> Result<()>;
+
+    fn mark_mined(&mut self, outpoint: OutPoint, mined_in_block: BlockHash) -> Result<()>;
+
+    fn revert_spent_status(&mut self, outpoint: OutPoint) -> Result<()>;
+}


### PR DESCRIPTION
This PR intends to do a complete rework of the role of sp-client in regards to the callers of the library (e.g. Dana wallet).

## Sp Client

Rework Sp-client to be a thin wrapper around rust-silentpayments. Sp-client only contains the bare minimum to operate a wallet: A scan key (private), a spend key (public/private), and the current bitcoin network.

## Updater

Add a 'Updater' trait. This trait tells the caller that a certain persistent operation should be handled (e.g. 'mark this transaction mined').

## ChainBackend

Add a 'ChainBackend' trait. This trait is called whenever chain data is required. For example, 'get utxos from this block'.

We also add a 'BlindbitBackend', which implements the ChainBackend trait. The BlindbitBackend is behind the optional 'blindbit-backend' feature.

## Sp Scanner

Finally, there is the Sp Scanner. This is a new struct that goes along with the Sp client. The Sp Scanner takes a Sp-client, along with a boxed ChainBackend and Updater. 

The scanner has a `scan_blocks` function, that takes a range and will scan the blocks for transactions. SpScanner requests block/utxo data from the ChainBackend. Whenever a new output is found, it calls 'updater.record_block_outputs', with the found outputs. The caller is then responsible for recording these outputs in their persistent storage.


### Note

The trait definitions are very primitive, and they are clearly written around the blindbit model. The trait definitions should therefore not be considered final, but rather a starting point to be iterated on later.