### PR TITLE
Expand recipient address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "sp_client"
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
-silentpayments = "0.3"
+silentpayments = { git = "https://github.com/Sosthene00/rust-silentpayments.git", branch = "address-serialization" }
 anyhow = "1.0"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4"
 async-trait = "0.1"
 reqwest = { version = "0.12.4", features = ["rustls-tls"], default-features = false, optional = true }
 hex = { version = "0.4.3", features = ["serde"], optional = true }
+bdk_coin_select ={ git = "https://github.com/bitcoindevkit/coin-select.git", rev = "c22b30b7dcc8d20d861033580abd0bcbd1e07f91" }
 
 [features]
 blindbit-backend = ["reqwest", "hex"]

--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -7,6 +7,7 @@ use bitcoin::{
     Address, Amount, Network, OutPoint, ScriptBuf, Transaction, TxIn, TxOut,
 };
 use serde::{Deserialize, Serialize};
+use silentpayments::utils::SilentPaymentAddress;
 
 type SpendingTxId = String;
 type MinedInBlock = String;
@@ -31,7 +32,7 @@ pub struct OwnedOutput {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum RecipientAddress {
     LegacyAddress(Address<NetworkUnchecked>),
-    SpAddress(String), // We need to implement Serialize for SilentPaymentAddress
+    SpAddress(SilentPaymentAddress), // We need to implement Serialize for SilentPaymentAddress
     Data(Vec<u8>),     // OpReturn output
 }
 

--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -1,10 +1,8 @@
+use std::str::FromStr;
+
 use anyhow::Error;
 use bitcoin::{
-    absolute::Height,
-    address::NetworkUnchecked,
-    key::Secp256k1,
-    secp256k1::{PublicKey, SecretKey},
-    Address, Amount, Network, OutPoint, ScriptBuf, Transaction, TxIn, TxOut,
+    absolute::Height, address::NetworkUnchecked, hex::{DisplayHex, FromHex}, key::Secp256k1, secp256k1::{PublicKey, SecretKey}, Address, Amount, Network, OutPoint, ScriptBuf, Transaction, TxOut
 };
 use serde::{Deserialize, Serialize};
 use silentpayments::utils::SilentPaymentAddress;
@@ -34,6 +32,32 @@ pub enum RecipientAddress {
     LegacyAddress(Address<NetworkUnchecked>),
     SpAddress(SilentPaymentAddress), // We need to implement Serialize for SilentPaymentAddress
     Data(Vec<u8>),     // OpReturn output
+}
+
+impl TryFrom<String> for RecipientAddress {
+    type Error = anyhow::Error;
+    fn try_from(value: String) -> Result<Self, Self::Error> {        
+        if let Ok(sp_address) = SilentPaymentAddress::try_from(value.as_str()) {
+            Ok(Self::SpAddress(sp_address.into()))
+        } else if let Ok(legacy_address) = Address::from_str(&value) {
+            Ok(Self::LegacyAddress(legacy_address))
+        } else if let Ok(data) = Vec::from_hex(&value) {
+            Ok(Self::Data(data))
+        } else {
+            Err(anyhow::Error::msg("Unknown recipient address type"))
+        }
+    } 
+
+}
+
+impl From<RecipientAddress> for String {
+    fn from(value: RecipientAddress) -> Self {
+        match value {
+            RecipientAddress::LegacyAddress(address) => address.assume_checked().to_string(),
+            RecipientAddress::SpAddress(sp_address) => sp_address.to_string(),
+            RecipientAddress::Data(data) => data.to_lower_hex_string(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]


### PR DESCRIPTION
Some improvements on the `RecipientAddress`:
* Now have a proper type `SilentPaymentAddress` for the case `SpAddress`
* remove a bunch of type conversion between `SilentPaymentAddress` and `String`
* Proper implementations of `TryFrom<String>` and `From<SilentPaymentAddress>`