### PR TITLE
Register spent transaction with txid or blockid raw bytes not hex string

### DIFF
--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -12,8 +12,8 @@ use bitcoin::{
 use serde::{Deserialize, Serialize};
 use silentpayments::{receiving::Label, SilentPaymentAddress};
 
-type SpendingTxId = String;
-type MinedInBlock = String;
+type SpendingTxId = [u8; 32];
+type MinedInBlock = [u8; 32];
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum OutputSpendStatus {


### PR DESCRIPTION
A very straightforward change, but I think it would be better for efficiency and consistency