### PR TITLE
feat(spdk-wallet): allow for scanning in reverse order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0.107"
 bitcoin = { version = "0.32.8", features = ["serde", "rand", "base64"] }
 bitcoin_hashes = "0.13.0"
 rayon = "1.10.0"
+itertools = "0.14.0"
 futures = "0.3"
 async-trait = "0.1"
 log = "0.4"

--- a/backend-blindbit-v1/Cargo.toml
+++ b/backend-blindbit-v1/Cargo.toml
@@ -18,3 +18,4 @@ serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true
 hex.workspace = true
+itertools.workspace = true

--- a/backend-blindbit-v1/src/backend.rs
+++ b/backend-blindbit-v1/src/backend.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use bitcoin::{Amount, absolute::Height};
 use futures::{Stream, StreamExt, stream};
 
+use itertools::Either;
 use spdk_core::chain::{BlockData, ChainBackend, SpentIndexData, UtxoData};
 
 use crate::BlindbitClient;
@@ -31,10 +32,16 @@ impl ChainBackend for BlindbitBackend {
     fn get_block_data_for_range(
         &self,
         range: RangeInclusive<u32>,
+        reverse: bool,
         dust_limit: Amount,
         with_cutthrough: bool,
     ) -> Pin<Box<dyn Stream<Item = Result<BlockData>> + Send>> {
         let client = self.client.clone();
+
+        let range = match reverse {
+            false => Either::Left(range),
+            true => Either::Right(range.rev()),
+        };
 
         let res = stream::iter(range)
             .map(move |n| {

--- a/spdk-core/src/chain/trait.rs
+++ b/spdk-core/src/chain/trait.rs
@@ -12,6 +12,7 @@ pub trait ChainBackend {
     fn get_block_data_for_range(
         &self,
         range: RangeInclusive<u32>,
+        reverse: bool,
         dust_limit: Amount,
         with_cutthrough: bool,
     ) -> Pin<Box<dyn Stream<Item = Result<BlockData>> + Send>>;

--- a/spdk-wallet/examples/simple_scanner.rs
+++ b/spdk-wallet/examples/simple_scanner.rs
@@ -101,11 +101,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         &keep_scanning,
     );
 
-    let start = Height::from_consensus(SCAN_START_HEIGHT)?;
-    let end = Height::from_consensus(SCAN_END_HEIGHT)?;
-
     scanner
-        .scan_blocks(start, end, DUST_LIMIT, WITH_CUTTHROUGH)
+        .scan_blocks(
+            SCAN_START_HEIGHT..=SCAN_END_HEIGHT,
+            false,
+            DUST_LIMIT,
+            WITH_CUTTHROUGH,
+        )
         .await?;
 
     // print all received updates

--- a/spdk-wallet/src/scanner/scanner.rs
+++ b/spdk-wallet/src/scanner/scanner.rs
@@ -1,10 +1,11 @@
 use std::{
     collections::{HashMap, HashSet},
+    ops::RangeInclusive,
     sync::atomic::AtomicBool,
     time::Instant,
 };
 
-use anyhow::{Error, Result, bail};
+use anyhow::{Error, Result};
 use bitcoin::{
     Amount, BlockHash, OutPoint, Txid, XOnlyPublicKey,
     absolute::Height,
@@ -48,23 +49,17 @@ impl<'a> SpScanner<'a> {
 
     pub async fn scan_blocks(
         &mut self,
-        start: Height,
-        end: Height,
+        range: RangeInclusive<u32>,
+        reverse: bool,
         dust_limit: Amount,
         with_cutthrough: bool,
     ) -> Result<()> {
-        if start > end {
-            bail!("bigger start than end: {} > {}", start, end);
-        }
-
-        info!("start: {} end: {}", start, end);
         let start_time: Instant = Instant::now();
 
         // get block data stream
-        let range = start.to_consensus_u32()..=end.to_consensus_u32();
         let block_data_stream =
             self.backend
-                .get_block_data_for_range(range, dust_limit, with_cutthrough);
+                .get_block_data_for_range(range, reverse, dust_limit, with_cutthrough);
 
         // process blocks using block data stream
         self.process_blocks(block_data_stream).await?;

--- a/spdk-wallet/tests/mock/chain.rs
+++ b/spdk-wallet/tests/mock/chain.rs
@@ -17,6 +17,7 @@ impl ChainBackend for MockChainBackend {
     fn get_block_data_for_range(
         &self,
         range: RangeInclusive<u32>,
+        _reverse: bool,
         _dust_limit: Amount,
         _with_cutthrough: bool,
     ) -> Pin<Box<dyn Stream<Item = Result<BlockData>> + Send>> {

--- a/spdk-wallet/tests/test.rs
+++ b/spdk-wallet/tests/test.rs
@@ -47,7 +47,12 @@ async fn simple_scan_single_block() {
         .unwrap();
 
     scanner
-        .scan_blocks(block_height, block_height, DUST_LIMIT, true)
+        .scan_blocks(
+            block_height.to_consensus_u32()..=block_height.to_consensus_u32(),
+            false,
+            DUST_LIMIT,
+            true,
+        )
         .await
         .unwrap();
 
@@ -102,7 +107,12 @@ async fn simple_scan_multiple_blocks() {
             .unwrap();
 
     scanner
-        .scan_blocks(first_block_height, second_block_height, DUST_LIMIT, true)
+        .scan_blocks(
+            first_block_height.to_consensus_u32()..=second_block_height.to_consensus_u32(),
+            false,
+            DUST_LIMIT,
+            true,
+        )
         .await
         .unwrap();
 
@@ -166,10 +176,10 @@ async fn scan_single_block_with_output() {
         &keep_scanning,
     );
 
-    let block_height: Height = Height::from_consensus(295125).unwrap();
+    let block_height: u32 = 295125;
 
     scanner
-        .scan_blocks(block_height, block_height, DUST_LIMIT, true)
+        .scan_blocks(block_height..=block_height, false, DUST_LIMIT, true)
         .await
         .unwrap();
 
@@ -224,10 +234,10 @@ async fn scan_single_block_with_spent_input() {
         &keep_scanning,
     );
 
-    let block_height: Height = Height::from_consensus(295147).unwrap();
+    let block_height: u32 = 295147;
 
     scanner
-        .scan_blocks(block_height, block_height, DUST_LIMIT, true)
+        .scan_blocks(block_height..=block_height, false, DUST_LIMIT, true)
         .await
         .unwrap();
 


### PR DESCRIPTION
Add a 'reverse' boolean to scan_blocks, that determines if we should return the results in forward or backward order.