### PR TITLE
Silentpayments refactor

### DIFF
--- a/silentpayments/examples/create_wallet.rs
+++ b/silentpayments/examples/create_wallet.rs
@@ -7,7 +7,7 @@ use bitcoin::secp256k1::Secp256k1;
 
 // Import types from the silentpayments library
 use silentpayments::receiving::{Label, Receiver};
-use silentpayments::Network;
+use silentpayments::{Network, SpVersion};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Create a new instance of Secp256k1 for cryptographic operations
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Create a new Receiver object with the private and public keys, along with the change label
     let receiver = Receiver::new(
-        0,
+        SpVersion::ZERO,
         scan_privkey.public_key(&secp),
         spend_privkey.public_key(&secp),
         change_label,

--- a/silentpayments/examples/custom_parser.rs
+++ b/silentpayments/examples/custom_parser.rs
@@ -34,9 +34,8 @@ fn main() {
         scan_pubkey,
         spend_pubkey,
         Network::Mainnet,
-        0, // version
-    )
-    .expect("Failed to create address");
+        silentpayments::SpVersion::ZERO, 
+    );
 
     println!("Successfully created SilentPaymentAddress without encode feature!");
     println!("Network: {:?}", address.get_network());

--- a/silentpayments/examples/find_output.rs
+++ b/silentpayments/examples/find_output.rs
@@ -8,6 +8,7 @@ use bitcoin::secp256k1::{PublicKey, Secp256k1, XOnlyPublicKey};
 use bitcoin::{Network, PrivateKey, ScriptBuf, Transaction};
 use bitcoin_hashes::hex::FromHex;
 
+use silentpayments::SpVersion;
 // Import types from the silentpayments library
 use silentpayments::receiving::{Label, Receiver};
 use silentpayments::utils::receiving::{
@@ -51,7 +52,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Create a new Receiver object with the private and public keys, along with the change label
     let receiver = Receiver::new(
-        0,
+        SpVersion::ZERO,
         scan_privkey.public_key(&secp),
         spend_privkey.public_key(&secp),
         change_label,

--- a/silentpayments/examples/find_output.rs
+++ b/silentpayments/examples/find_output.rs
@@ -11,6 +11,7 @@ use bitcoin_hashes::hex::FromHex;
 use silentpayments::SpVersion;
 // Import types from the silentpayments library
 use silentpayments::receiving::{Label, Receiver};
+use silentpayments::utils::{MAIN_SCAN_PATH, MAIN_SPEND_PATH};
 use silentpayments::utils::receiving::{
     calculate_ecdh_shared_secret, calculate_tweak_data, get_pubkey_from_input,
 };
@@ -22,26 +23,14 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Parse the mnemonic phrase from the first command-line argument
     let m = Mnemonic::from_str(&args.get(1).unwrap())?;
 
-    // Get the transaction hex string from the second command-line argument
-    let tx_hex = args.get(2).unwrap();
-
-    // Parse the scriptpubkeys from the third command-line argument, split by whitespace and store them in a vector
-    let spks: Vec<&str> = args.get(3).unwrap().split_whitespace().collect();
-
-    // Deserialize the transaction hex string into a Transaction object
-    let tx: Transaction = deserialize(Vec::from_hex(&tx_hex)?.as_slice())?;
-
-    // Assert that the number of inputs in the transaction matches the number of scriptpubkeys provided
-    assert!(tx.input.len() == spks.len());
-
-    let master_key = Xpriv::new_master(bitcoin::Network::Signet, &m.to_seed(""))?;
+    let master_key = Xpriv::new_master(bitcoin::Network::Bitcoin, &m.to_seed(""))?;
 
     // Define the scan and spend paths for the wallet
-    let scan_path = DerivationPath::from_str("m/352h/1h/0h/1h/0").unwrap();
-    let spend_path = DerivationPath::from_str("m/352h/1h/0h/0h/0").unwrap();
+    let scan_path = DerivationPath::from_str(MAIN_SCAN_PATH).unwrap();
+    let spend_path = DerivationPath::from_str(MAIN_SPEND_PATH).unwrap();
 
     // Create a new instance of Secp256k1 for cryptographic operations
-    let secp = Secp256k1::signing_only();
+    let secp = Secp256k1::new();
 
     // Get the private keys for both scan and spend paths
     let scan_privkey = master_key.derive_priv(&secp, &scan_path)?.private_key;
@@ -56,8 +45,22 @@ fn main() -> Result<(), Box<dyn Error>> {
         scan_privkey.public_key(&secp),
         spend_privkey.public_key(&secp),
         change_label,
-        silentpayments::Network::Testnet,
+        silentpayments::Network::Mainnet,
     )?;
+
+    assert_eq!(receiver.get_receiving_address().to_string().as_str(), "sp1qq2h0tcwserlsk6yszaa54jtse9s9ype47r4f0y9gkp7mn7zwn4q07qslxzntmfu5euy2dwj2v4wk8dxanurpzat628rvkdns2a8f2fk9gs9wazmu");
+
+    // Get the transaction hex string from the second command-line argument
+    let tx_hex = args.get(2).unwrap();
+
+    // Parse the scriptpubkeys from the third command-line argument, split by whitespace and store them in a vector
+    let spks: Vec<&str> = args.get(3).unwrap().split_whitespace().collect();
+
+    // Deserialize the transaction hex string into a Transaction object
+    let tx: Transaction = deserialize(Vec::from_hex(&tx_hex)?.as_slice())?;
+
+    // Assert that the number of inputs in the transaction matches the number of scriptpubkeys provided
+    assert!(tx.input.len() == spks.len());
 
     // Extract outpoints (previous transaction outputs) from the transaction inputs and store them in a vector
     let outpoints: Vec<[u8; 36]> = tx

--- a/silentpayments/examples/find_output.rs
+++ b/silentpayments/examples/find_output.rs
@@ -91,7 +91,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let (outpoints_head, outpoints_tail) = outpoints.split_first().unwrap();
 
     // Calculate the tweak data based on the public keys and outpoints
-    let tweak_data = calculate_tweak_data(&pubkeys_ref, outpoints_head, outpoints_tail)?;
+    let tweak_data = calculate_tweak_data(&secp, &pubkeys_ref, outpoints_head, outpoints_tail)?;
 
     // Calculate the ECDH shared secret between the scan private key and the tweak data
     let ecdh_shared_secret = calculate_ecdh_shared_secret(&tweak_data, &scan_privkey);

--- a/silentpayments/examples/find_output.rs
+++ b/silentpayments/examples/find_output.rs
@@ -3,7 +3,7 @@ use std::{env, error::Error, str::FromStr};
 // Import necessary libraries and modules
 use bip39::Mnemonic;
 use bitcoin::bip32::{DerivationPath, Xpriv};
-use bitcoin::consensus::deserialize;
+use bitcoin::consensus::{deserialize, serialize};
 use bitcoin::secp256k1::{PublicKey, Secp256k1, XOnlyPublicKey};
 use bitcoin::{Network, PrivateKey, ScriptBuf, Transaction};
 use bitcoin_hashes::hex::FromHex;
@@ -60,12 +60,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     )?;
 
     // Extract outpoints (previous transaction outputs) from the transaction inputs and store them in a vector
-    let outpoints: Vec<(String, u32)> = tx
+    let outpoints: Vec<[u8; 36]> = tx
         .input
         .iter()
         .map(|i| {
             let outpoint = i.previous_output;
-            (outpoint.txid.to_string(), outpoint.vout)
+            serialize(&outpoint).try_into().unwrap()
         })
         .collect();
 
@@ -85,8 +85,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Get the reference to a vector of public keys for further calculations
     let pubkeys_ref: Vec<&PublicKey> = input_pubkeys.iter().collect();
 
+    let (outpoints_head, outpoints_tail) = outpoints.split_first().unwrap();
+
     // Calculate the tweak data based on the public keys and outpoints
-    let tweak_data = calculate_tweak_data(&pubkeys_ref, &outpoints)?;
+    let tweak_data = calculate_tweak_data(&pubkeys_ref, outpoints_head, outpoints_tail)?;
 
     // Calculate the ECDH shared secret between the scan private key and the tweak data
     let ecdh_shared_secret = calculate_ecdh_shared_secret(&tweak_data, &scan_privkey);

--- a/silentpayments/src/lib.rs
+++ b/silentpayments/src/lib.rs
@@ -53,5 +53,6 @@ pub use secp256k1;
 pub use crate::error::Error;
 pub use utils::common::Network;
 pub use utils::common::SilentPaymentAddress;
+pub use utils::common::SpVersion;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/silentpayments/src/receiving.rs
+++ b/silentpayments/src/receiving.rs
@@ -130,7 +130,7 @@ impl<'de> Deserialize<'de> for Label {
 /// Labels can be added with [`add_label`](Receiver::add_label).
 #[derive(Debug, Clone, PartialEq)]
 pub struct Receiver {
-    version: u8,
+    version: SpVersion,
     scan_pubkey: PublicKey,
     spend_pubkey: PublicKey,
     change_label: Label, // To be able to tell which label is the change
@@ -225,7 +225,7 @@ impl Serialize for Receiver {
         S: serde::Serializer,
     {
         let mut state = serializer.serialize_struct("Receiver", 5)?;
-        state.serialize_field("version", &self.version)?;
+        state.serialize_field::<u8>("version", &self.version.into())?;
         state.serialize_field("network", &self.network)?;
         state.serialize_field(
             "scan_pubkey",
@@ -258,7 +258,7 @@ impl<'de> Deserialize<'de> for Receiver {
     {
         let helper = ReceiverHelper::deserialize(deserializer)?;
         Ok(Receiver {
-            version: helper.version,
+            version: helper.version.try_into().unwrap(),
             network: helper.network,
             scan_pubkey: PublicKey::from_slice(&helper.scan_pubkey.0).unwrap(),
             spend_pubkey: PublicKey::from_slice(&helper.spend_pubkey.0).unwrap(),
@@ -270,7 +270,7 @@ impl<'de> Deserialize<'de> for Receiver {
 
 impl Receiver {
     pub fn new(
-        version: u32,
+        version: SpVersion,
         scan_pubkey: PublicKey,
         spend_pubkey: PublicKey,
         change_label: Label,
@@ -278,15 +278,8 @@ impl Receiver {
     ) -> Result<Self> {
         let labels: BiMap<Label, PublicKey> = BiMap::new();
 
-        // Check version, we just refuse anything other than 0 for now
-        if version != 0 {
-            return Err(Error::GenericError(
-                "Can't have other version than 0 for now".to_owned(),
-            ));
-        }
-
         let mut receiver = Receiver {
-            version: version as u8,
+            version,
             scan_pubkey,
             spend_pubkey,
             change_label: change_label.clone(),
@@ -477,8 +470,7 @@ impl Receiver {
     }
 
     fn get_silent_payment_address(&self, m_pubkey: PublicKey) -> SilentPaymentAddress {
-        SilentPaymentAddress::new(self.scan_pubkey, m_pubkey, self.network, 0)
-            .expect("only fails if version != 0")
+        SilentPaymentAddress::new(self.scan_pubkey, m_pubkey, self.network, self.version)
     }
 }
 

--- a/silentpayments/src/receiving.rs
+++ b/silentpayments/src/receiving.rs
@@ -382,14 +382,14 @@ impl Receiver {
         ecdh_shared_secret: &PublicKey,
         pubkeys_to_check: &[XOnlyPublicKey],
     ) -> Result<HashMap<Option<Label>, HashMap<XOnlyPublicKey, Scalar>>> {
-        let secp = secp256k1::Secp256k1::new();
+        let secp = secp256k1::Secp256k1::verification_only();
 
         let mut found: HashMap<Option<Label>, HashMap<XOnlyPublicKey, Scalar>> = HashMap::new();
         let mut n_found: u32 = 0;
         let mut n: u32 = 0;
         while n_found == n {
             let t_n: SecretKey = calculate_t_n(ecdh_shared_secret, n)?;
-            let P_n: PublicKey = calculate_P_n(&self.spend_pubkey, t_n.into())?;
+            let P_n: PublicKey = calculate_P_n(&secp, &self.spend_pubkey, t_n.into())?;
             let P_n_xonly = P_n.x_only_public_key().0;
             if pubkeys_to_check.iter().any(|p| p.eq(&P_n_xonly)) {
                 n_found += 1;
@@ -441,8 +441,9 @@ impl Receiver {
         &self,
         ecdh_shared_secret: &PublicKey,
     ) -> Result<HashMap<Option<Label>, [u8; 34]>> {
+        let secp = Secp256k1::verification_only();
         let t_0: SecretKey = calculate_t_n(ecdh_shared_secret, 0)?;
-        let P_0: PublicKey = calculate_P_n(&self.spend_pubkey, t_0.into())?;
+        let P_0: PublicKey = calculate_P_n(&secp, &self.spend_pubkey, t_0.into())?;
         let output_key_bytes = P_0.x_only_public_key().0.serialize();
 
         let mut res = HashMap::new();
@@ -456,7 +457,7 @@ impl Receiver {
 
         for (label, mG) in &self.labels {
             let B_m = mG.combine(&self.spend_pubkey)?;
-            let P_m0 = calculate_P_n(&B_m, t_0.into())?;
+            let P_m0 = calculate_P_n(&secp, &B_m, t_0.into())?;
             let output_key_bytes = P_m0.x_only_public_key().0.serialize();
 
             let mut spk = [0u8; 34];

--- a/silentpayments/src/receiving.rs
+++ b/silentpayments/src/receiving.rs
@@ -16,11 +16,10 @@ use std::{
 };
 
 use crate::{
-    utils::{
-        common::{calculate_P_n, calculate_t_n},
+    Error, Network, Result, SilentPaymentAddress, utils::{
+        common::{SpVersion, calculate_P_n, calculate_t_n},
         hash::LabelHash,
-    },
-    Error, Network, Result, SilentPaymentAddress,
+    }
 };
 use bimap::BiMap;
 use secp256k1::{Parity, PublicKey, Scalar, Secp256k1, SecretKey, XOnlyPublicKey};

--- a/silentpayments/src/sending.rs
+++ b/silentpayments/src/sending.rs
@@ -11,10 +11,20 @@
 use secp256k1::{PublicKey, Secp256k1, SecretKey, XOnlyPublicKey};
 use std::collections::HashMap;
 
+use crate::Network;
+use crate::utils::common::SpVersion;
 use crate::utils::common::calculate_t_n;
 use crate::utils::sending::calculate_ecdh_shared_secret;
 use crate::Result;
 use crate::SilentPaymentAddress;
+
+#[derive(Debug)]
+pub struct GeneratePubkeysInput {
+    pub scan_key: PublicKey,
+    pub ecdh_shared_secret: PublicKey,
+    pub spend_keys: Vec<PublicKey>, 
+    pub sp_version: SpVersion,
+}
 
 /// Create outputs for a given set of silent payment recipients and their corresponding shared secrets.
 ///

--- a/silentpayments/src/sending.rs
+++ b/silentpayments/src/sending.rs
@@ -1,20 +1,21 @@
-//! The sending component of silent payments.
+//! Sending-side output key derivation for Silent Payments.
 //!
-//! The [`generate_recipient_pubkeys`] function can be used to create outputs for a list of silent payment recipients.
+//! Use [`generate_recipient_pubkeys`] with one or more [`GeneratePubkeysInput`] items.
+//! Each item contains:
+//! - the recipient scan key,
+//! - the ECDH shared secret for that recipient/input set, and
+//! - the recipient spend keys to derive output pubkeys for.
 //!
 //! Using [`generate_recipient_pubkeys`] will require calculating a
-//! `partial_secret` beforehand.
-//! To do this, you can use [`calculate_partial_secret`](crate::utils::sending::calculate_partial_secret) from the `utils` module.
-//! See the [tests on github](https://github.com/cygnet3/rust-silentpayments/blob/master/tests/vector_tests.rs)
-//! for a concrete example.
+//! `ecdh_shared_secret` for each scan key beforehand.
 
-use secp256k1::{PublicKey, Secp256k1, SecretKey, XOnlyPublicKey};
+use secp256k1::Signing;
+use secp256k1::{PublicKey, Secp256k1, XOnlyPublicKey};
 use std::collections::HashMap;
 
 use crate::Network;
 use crate::utils::common::SpVersion;
 use crate::utils::common::calculate_t_n;
-use crate::utils::sending::calculate_ecdh_shared_secret;
 use crate::Result;
 use crate::SilentPaymentAddress;
 
@@ -28,62 +29,47 @@ pub struct GeneratePubkeysInput {
 
 /// Create outputs for a given set of silent payment recipients and their corresponding shared secrets.
 ///
-/// When creating the outputs for a transaction, this function should be used to generate the output keys.
+/// When creating transaction outputs, call this function once with all recipients.
 ///
-/// This function should only be used once per transaction! If used multiple times, address reuse may occur.
+/// Calling it multiple times for the same transaction can reuse address indexes.
 ///
 /// # Arguments
 ///
-/// * `recipients` - A [Vec] of silent payment addresses strings to be paid.
-/// * `partial_secret` - A [SecretKey] that represents the sum of the private keys of eligible inputs of the transaction multiplied by the input hash.
+/// * `inputs` - A collection of [`GeneratePubkeysInput`] values. Each value
+///   provides the recipient scan key, ECDH shared secret, spend keys, and
+///   silent payment version used for derivation.
+/// * `network` - The target Bitcoin network used when constructing
+///   [`SilentPaymentAddress`] values.
 ///
 /// # Returns
 ///
-/// If successful, the function returns a [Result] wrapping a [HashMap] of silent payment addresses to a [Vec].
-/// The [Vec] contains all the outputs that are associated with the silent payment address.
+/// Returns a [`HashMap`] from [`SilentPaymentAddress`] to derived output
+/// [`XOnlyPublicKey`] values for that address.
 ///
 /// # Errors
 ///
 /// This function will return an error if:
 ///
-/// * The recipients [Vec] contains a silent payment address with an incorrect format.
 /// * Edge cases are hit during elliptic curve computation (extremely unlikely).
-pub fn generate_recipient_pubkeys(
-    recipients: Vec<SilentPaymentAddress>,
-    partial_secret: SecretKey,
+pub fn generate_recipient_pubkeys<C: Signing>(
+    secp: &Secp256k1<C>,
+    inputs: Vec<GeneratePubkeysInput>,
+    network: Network
 ) -> Result<HashMap<SilentPaymentAddress, Vec<XOnlyPublicKey>>> {
-    let secp = Secp256k1::new();
-
-    let mut silent_payment_groups: HashMap<PublicKey, (PublicKey, Vec<SilentPaymentAddress>)> =
-        HashMap::new();
-    for address in recipients {
-        let B_scan = address.get_scan_key();
-
-        if let Some((_, payments)) = silent_payment_groups.get_mut(&B_scan) {
-            payments.push(address);
-        } else {
-            let ecdh_shared_secret = calculate_ecdh_shared_secret(&B_scan, &partial_secret);
-
-            silent_payment_groups.insert(B_scan, (ecdh_shared_secret, vec![address]));
-        }
-    }
-
     let mut result: HashMap<SilentPaymentAddress, Vec<XOnlyPublicKey>> = HashMap::new();
-    for group in silent_payment_groups.into_values() {
-        let mut n = 0;
-
-        let (ecdh_shared_secret, recipients) = group;
-
-        for addr in recipients {
-            let t_n = calculate_t_n(&ecdh_shared_secret, n)?;
-
-            let res = t_n.public_key(&secp);
-            let reskey = res.combine(&addr.get_spend_key())?;
+    for input in inputs {
+        let ecdh_shared_secret = &input.ecdh_shared_secret;
+        let mut k = 0;
+        for spend_key in input.spend_keys {
+            let address = SilentPaymentAddress::new(input.scan_key, spend_key, network, input.sp_version);
+            let t_n = calculate_t_n(ecdh_shared_secret, k)?;
+            let res = t_n.public_key(secp);
+            let reskey = res.combine(&address.get_spend_key())?;
             let (reskey_xonly, _) = reskey.x_only_public_key();
 
-            let entry = result.entry(addr.into()).or_default();
+            let entry = result.entry(address.into()).or_default();
             entry.push(reskey_xonly);
-            n += 1;
+            k += 1;
         }
     }
     Ok(result)

--- a/silentpayments/src/utils.rs
+++ b/silentpayments/src/utils.rs
@@ -31,6 +31,12 @@ const OP_CHECKSIG: u8 = 0xAC;
 // Only compressed pubkeys are supported for silent payments
 const COMPRESSED_PUBKEY_SIZE: usize = 33;
 
+// Derivation paths according to BIP
+pub const MAIN_SCAN_PATH: &str = "m/352h/0h/0h/1h/0";
+pub const MAIN_SPEND_PATH: &str = "m/352h/0h/0h/0h/0";
+pub const TEST_SCAN_PATH: &str = "m/352h/1h/0h/1h/0";
+pub const TEST_SPEND_PATH: &str = "m/352h/1h/0h/0h/0";
+
 // script templates for inputs allowed in BIP352 shared secret derivation
 /// Check if a script_pub_key is taproot.
 pub fn is_p2tr(spk: &[u8]) -> bool {

--- a/silentpayments/src/utils.rs
+++ b/silentpayments/src/utils.rs
@@ -30,3 +30,25 @@ const OP_CHECKSIG: u8 = 0xAC;
 
 // Only compressed pubkeys are supported for silent payments
 const COMPRESSED_PUBKEY_SIZE: usize = 33;
+
+// script templates for inputs allowed in BIP352 shared secret derivation
+/// Check if a script_pub_key is taproot.
+pub fn is_p2tr(spk: &[u8]) -> bool {
+    matches!(spk, [OP_1, OP_PUSHBYTES_32, ..] if spk.len() == 34)
+}
+
+fn is_p2wpkh(spk: &[u8]) -> bool {
+    matches!(spk, [OP_0, OP_PUSHBYTES_20, ..] if spk.len() == 22)
+}
+
+fn is_p2sh(spk: &[u8]) -> bool {
+    matches!(spk, [OP_HASH160, OP_PUSHBYTES_20, .., OP_EQUAL] if spk.len() == 23)
+}
+
+fn is_p2pkh(spk: &[u8]) -> bool {
+    matches!(spk, [OP_DUP, OP_HASH160, OP_PUSHBYTES_20, .., OP_EQUALVERIFY, OP_CHECKSIG] if spk.len() == 25)
+}
+
+pub fn is_eligible(spk: &[u8]) -> bool {
+    is_p2tr(spk) || is_p2pkh(spk) || is_p2sh(spk) || is_p2wpkh(spk)
+}

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -11,7 +11,7 @@ use bech32::{FromBase32, ToBase32};
 use bitcoin_hashes::Hash;
 use secp256k1::PublicKey;
 #[cfg(any(feature = "sending", feature = "receiving"))]
-use secp256k1::{Scalar, Secp256k1, SecretKey};
+use secp256k1::{Scalar, Secp256k1, SecretKey, Verification};
 #[cfg(all(feature = "serde", feature = "encode"))]
 use serde::ser::Serializer;
 #[cfg(all(feature = "serde", feature = "encode"))]
@@ -28,10 +28,8 @@ pub(crate) fn calculate_t_n(ecdh_shared_secret: &PublicKey, k: u32) -> Result<Se
 }
 
 #[cfg(any(feature = "sending", feature = "receiving"))]
-pub(crate) fn calculate_P_n(B_spend: &PublicKey, t_n: Scalar) -> Result<PublicKey> {
-    let secp = Secp256k1::new();
-
-    let P_n = B_spend.add_exp_tweak(&secp, &t_n)?;
+pub(crate) fn calculate_P_n<C: Verification>(secp: &Secp256k1<C>, B_spend: &PublicKey, t_n: Scalar) -> Result<PublicKey> {
+    let P_n = B_spend.add_exp_tweak(secp, &t_n)?;
 
     Ok(P_n)
 }

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -72,10 +72,34 @@ impl TryFrom<&str> for Network {
     }
 }
 
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum SpVersion {
+    ZERO,
+}
+
+impl From<SpVersion> for u8 {
+    fn from(value: SpVersion) -> Self {
+        match value {
+            SpVersion::ZERO => 0u8
+        }
+    }
+}
+
+impl TryFrom<u8> for SpVersion {
+    type Error = crate::Error;
+
+    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::ZERO),
+            _ => Err(Error::GenericError("Unknwon silent payment version".to_string()))
+        }
+    }
+}
+
 /// A silent payment address struct that can be used to deserialize a silent payment address string.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct SilentPaymentAddress {
-    version: u8,
+    version: SpVersion,
     scan_pubkey: PublicKey,
     m_pubkey: PublicKey,
     network: Network,
@@ -141,20 +165,14 @@ impl SilentPaymentAddress {
         scan_pubkey: PublicKey,
         m_pubkey: PublicKey,
         network: Network,
-        version: u8,
-    ) -> Result<Self> {
-        if version != 0 {
-            return Err(Error::GenericError(
-                "Can't have other version than 0 for now".to_owned(),
-            ));
-        }
-
-        Ok(SilentPaymentAddress {
+        version: SpVersion,
+    ) -> Self {
+        SilentPaymentAddress {
             scan_pubkey,
             m_pubkey,
             network,
-            version,
-        })
+            version
+        }
     }
 
     /// Get the scan public key.
@@ -174,7 +192,7 @@ impl SilentPaymentAddress {
 
     /// Get the version byte.
     pub fn get_version(&self) -> u8 {
-        self.version
+        self.version.into()
     }
 }
 
@@ -196,7 +214,7 @@ impl TryFrom<&str> for SilentPaymentAddress {
             return Err(Error::GenericError("Address length is wrong".to_owned()));
         }
 
-        let version = data[0].to_u8();
+        let version: SpVersion = data[0].to_u8().try_into()?;
 
         let network = match hrp.as_str() {
             "sp" => Network::Mainnet,
@@ -215,7 +233,7 @@ impl TryFrom<&str> for SilentPaymentAddress {
         let scan_pubkey = PublicKey::from_slice(&data[..33])?;
         let m_pubkey = PublicKey::from_slice(&data[33..])?;
 
-        SilentPaymentAddress::new(scan_pubkey, m_pubkey, network, version)
+        Ok(SilentPaymentAddress::new(scan_pubkey, m_pubkey, network, version))
     }
 }
 
@@ -237,7 +255,7 @@ impl From<SilentPaymentAddress> for String {
             Network::Mainnet => "sp",
         };
 
-        let version = bech32::u5::try_from_u8(val.version).unwrap();
+        let version = bech32::u5::try_from_u8(val.version.into()).unwrap();
 
         let B_scan_bytes = val.scan_pubkey.serialize();
         let B_m_bytes = val.m_pubkey.serialize();

--- a/silentpayments/src/utils/hash.rs
+++ b/silentpayments/src/utils/hash.rs
@@ -1,6 +1,7 @@
-use crate::Error;
 use bitcoin_hashes::{sha256t_hash_newtype, Hash, HashEngine};
 use secp256k1::{PublicKey, Scalar, SecretKey};
+
+pub(super) const OUTPOINTS_LEN: usize = 36;
 
 sha256t_hash_newtype! {
     pub(crate) struct InputsTag = hash_str("BIP0352/Inputs");
@@ -67,46 +68,12 @@ impl SharedSecretHash {
     }
 }
 
-pub(crate) fn calculate_input_hash(
-    outpoints_data: &[(String, u32)],
+pub fn calculate_input_hash(
+    outpoint_head: &[u8; OUTPOINTS_LEN],
+    outpoints_tail: &[[u8; OUTPOINTS_LEN]],
     A_sum: PublicKey,
-) -> Result<Scalar, Error> {
-    if outpoints_data.is_empty() {
-        return Err(Error::GenericError("No outpoints provided".to_owned()));
-    }
+) -> Scalar {
+    let smallest_outpoint = outpoints_tail.iter().chain(std::iter::once(outpoint_head)).min().expect("Already checked for empty array");
 
-    let mut outpoints: Vec<[u8; 36]> = Vec::with_capacity(outpoints_data.len());
-
-    // should probably just use an OutPoints type properly at some point
-    for (txid, vout) in outpoints_data {
-        let mut bytes: Vec<u8> = hex::decode(txid.as_str())?;
-
-        if bytes.len() != 32 {
-            return Err(Error::GenericError(format!(
-                "Invalid outpoint hex representation: {}",
-                txid
-            )));
-        }
-
-        // txid in string format is big endian and we need little endian
-        bytes.reverse();
-
-        let mut buffer = [0u8; 36];
-
-        buffer[..32].copy_from_slice(&bytes);
-        buffer[32..].copy_from_slice(&vout.to_le_bytes());
-        outpoints.push(buffer);
-    }
-
-    // sort outpoints
-    outpoints.sort_unstable();
-
-    if let Some(smallest_outpoint) = outpoints.first() {
-        Ok(InputsHash::from_outpoint_and_A_sum(smallest_outpoint, A_sum).to_scalar())
-    } else {
-        // This should never happen
-        Err(Error::GenericError(
-            "Unexpected empty outpoints vector".to_owned(),
-        ))
-    }
+    InputsHash::from_outpoint_and_A_sum(smallest_outpoint, A_sum).to_scalar()
 }

--- a/silentpayments/src/utils/receiving.rs
+++ b/silentpayments/src/utils/receiving.rs
@@ -1,11 +1,11 @@
 //! Receiving utility functions.
 use crate::{
     Error, Result, utils::{
-        is_p2pkh, is_p2sh, is_p2tr, is_p2wpkh
+        hash::OUTPOINTS_LEN, is_p2pkh, is_p2sh, is_p2tr, is_p2wpkh
     }
 };
 use bitcoin_hashes::{hash160, Hash};
-use secp256k1::{ecdh::shared_secret_point, Parity::Even, XOnlyPublicKey};
+use secp256k1::{Parity::Even, Secp256k1, Verification, XOnlyPublicKey, ecdh::shared_secret_point};
 use secp256k1::{PublicKey, SecretKey};
 
 use super::{hash::calculate_input_hash, COMPRESSED_PUBKEY_SIZE, NUMS_H};
@@ -17,8 +17,10 @@ use super::{hash::calculate_input_hash, COMPRESSED_PUBKEY_SIZE, NUMS_H};
 ///
 /// # Arguments
 ///
+/// * `secp` - Secp256k1 context used for elliptic curve operations.
 /// * `input_pub_keys` - The list of public keys that are used as input for this transaction. Only the public keys for inputs that are silent payment eligible should be given.
-/// * `outpoints_data` - All prevout outpoints used as input for this transaction. Note that the txid is given in String format, which is displayed in reverse order from the inner byte array.
+/// * `outpoints_head` - The first prevout outpoint used as input for this transaction in serialized form.
+/// * `outpoints_tail` - The remaining prevout outpoints used as input for this transaction in serialized form.
 ///
 /// # Returns
 ///
@@ -30,12 +32,12 @@ use super::{hash::calculate_input_hash, COMPRESSED_PUBKEY_SIZE, NUMS_H};
 ///
 /// * The input public keys array is of length zero, or the summing results in an invalid key.
 /// * Elliptic curve computation results in an invalid public key.
-pub fn calculate_tweak_data(
+pub fn calculate_tweak_data<C: Verification>(
+    secp: &Secp256k1<C>,
     input_pub_keys: &[&PublicKey],
     outpoints_head: &[u8; OUTPOINTS_LEN],
     outpoints_tail: &[[u8; OUTPOINTS_LEN]]
 ) -> Result<PublicKey> {
-    let secp = secp256k1::Secp256k1::verification_only();
     let A_sum = PublicKey::combine_keys(input_pub_keys)?;
     let input_hash = calculate_input_hash(&outpoints_head, &outpoints_tail, A_sum);
 

--- a/silentpayments/src/utils/receiving.rs
+++ b/silentpayments/src/utils/receiving.rs
@@ -1,10 +1,8 @@
 //! Receiving utility functions.
 use crate::{
-    utils::{
-        OP_0, OP_1, OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160, OP_PUSHBYTES_20,
-        OP_PUSHBYTES_32,
-    },
-    Error, Result,
+    Error, Result, utils::{
+        is_p2pkh, is_p2sh, is_p2tr, is_p2wpkh
+    }
 };
 use bitcoin_hashes::{hash160, Hash};
 use secp256k1::{ecdh::shared_secret_point, Parity::Even, XOnlyPublicKey};
@@ -215,22 +213,4 @@ pub fn get_pubkey_from_input(
         }
     }
     Ok(None)
-}
-
-// script templates for inputs allowed in BIP352 shared secret derivation
-/// Check if a script_pub_key is taproot.
-pub fn is_p2tr(spk: &[u8]) -> bool {
-    matches!(spk, [OP_1, OP_PUSHBYTES_32, ..] if spk.len() == 34)
-}
-
-fn is_p2wpkh(spk: &[u8]) -> bool {
-    matches!(spk, [OP_0, OP_PUSHBYTES_20, ..] if spk.len() == 22)
-}
-
-fn is_p2sh(spk: &[u8]) -> bool {
-    matches!(spk, [OP_HASH160, OP_PUSHBYTES_20, .., OP_EQUAL] if spk.len() == 23)
-}
-
-fn is_p2pkh(spk: &[u8]) -> bool {
-    matches!(spk, [OP_DUP, OP_HASH160, OP_PUSHBYTES_20, .., OP_EQUALVERIFY, OP_CHECKSIG] if spk.len() == 25)
 }

--- a/silentpayments/src/utils/receiving.rs
+++ b/silentpayments/src/utils/receiving.rs
@@ -29,15 +29,15 @@ use super::{hash::calculate_input_hash, COMPRESSED_PUBKEY_SIZE, NUMS_H};
 /// This function will error if:
 ///
 /// * The input public keys array is of length zero, or the summing results in an invalid key.
-/// * The outpoints_data is of length zero, or invalid.
 /// * Elliptic curve computation results in an invalid public key.
 pub fn calculate_tweak_data(
     input_pub_keys: &[&PublicKey],
-    outpoints_data: &[(String, u32)],
+    outpoints_head: &[u8; OUTPOINTS_LEN],
+    outpoints_tail: &[[u8; OUTPOINTS_LEN]]
 ) -> Result<PublicKey> {
     let secp = secp256k1::Secp256k1::verification_only();
     let A_sum = PublicKey::combine_keys(input_pub_keys)?;
-    let input_hash = calculate_input_hash(outpoints_data, A_sum)?;
+    let input_hash = calculate_input_hash(&outpoints_head, &outpoints_tail, A_sum);
 
     Ok(A_sum.mul_tweak(&secp, &input_hash)?)
 }

--- a/silentpayments/src/utils/sending.rs
+++ b/silentpayments/src/utils/sending.rs
@@ -1,15 +1,143 @@
 //! Sending utility functions.
-use crate::{Error, Result};
-use secp256k1::{ecdh::shared_secret_point, PublicKey, Secp256k1, SecretKey};
+use std::marker::PhantomData;
+
+use crate::{Error, Result, utils::hash::OUTPOINTS_LEN};
+use secp256k1::{PublicKey, Secp256k1, SecretKey, Signing, ecdh::shared_secret_point};
 
 use super::hash::calculate_input_hash;
 
-/// Calculate the partial secret that is needed for generating the recipient pubkeys.
+/// Typestate marker: keys are not normalized yet.
+#[derive(Clone, Copy, Debug)]
+pub struct Raw;
+/// Typestate marker: taproot parity normalization was applied.
+#[derive(Clone, Copy, Debug)]
+pub struct Normalized;
+/// Typestate marker: BIP-352 input hash was applied.
+#[derive(Clone, Copy, Debug)]
+pub struct InputHashApplied;
+
+/// A typed secret key wrapper used to model derivation stages.
+#[derive(Clone, Copy, Debug)]
+pub struct TypedSecretKey<State> {
+    key: SecretKey,
+    _state: PhantomData<State>,
+}
+
+impl<State> TypedSecretKey<State> {
+    pub fn into_inner(self) -> SecretKey {
+        self.key
+    }
+
+    pub fn as_inner(&self) -> &SecretKey {
+        &self.key
+    }
+}
+
+impl TypedSecretKey<Normalized> {
+    fn from_inner(key: SecretKey) -> Self {
+        Self {
+            key,
+            _state: PhantomData,
+        }
+    }
+}
+
+impl TypedSecretKey<Raw> {
+    pub fn new(key: SecretKey) -> Self {
+        Self {
+            key,
+            _state: PhantomData,
+        }
+    }
+
+    /// Normalize this key for BIP-352 usage.
+    ///
+    /// For non-taproot inputs the key is unchanged.
+    /// For taproot inputs with odd-y pubkeys, the negated key is returned.
+    pub fn normalize_for_input<C: secp256k1::Signing>(
+        self,
+        secp: &Secp256k1<C>,
+        is_taproot: bool,
+    ) -> TypedSecretKey<Normalized> {
+        let (_, parity) = self.key.x_only_public_key(secp);
+        let key = if is_taproot && parity == secp256k1::Parity::Odd {
+            self.key.negate()
+        } else {
+            self.key
+        };
+
+        TypedSecretKey {
+            key,
+            _state: PhantomData,
+        }
+    }
+}
+
+impl TypedSecretKey<Normalized> {
+    /// Apply BIP-352 input hash to this normalized key.
+    pub fn apply_input_hash<C: Signing>(self, secp: &Secp256k1<C>, outpoints_head: &[u8; 36], outpoints_tail: &[[u8; 36]]) -> Result<SecretKey> {
+        let input_hash = calculate_input_hash(outpoints_head, outpoints_tail, self.as_inner().public_key(secp));
+        Ok(self.key.mul_tweak(&input_hash)?)
+    }
+}
+
+/// Non-empty normalized key collection.
+#[derive(Clone, Debug)]
+pub struct NonEmptyNormalizedKeys {
+    head: TypedSecretKey<Normalized>,
+    tail: Vec<TypedSecretKey<Normalized>>,
+}
+
+impl NonEmptyNormalizedKeys {
+    pub fn from_vec(keys: Vec<TypedSecretKey<Normalized>>) -> Result<Self> {
+        let mut iter = keys.into_iter();
+        let head = iter
+            .next()
+            .ok_or_else(|| Error::GenericError("No input provided".to_owned()))?;
+        Ok(Self {
+            head,
+            tail: iter.collect(),
+        })
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &TypedSecretKey<Normalized>> {
+        std::iter::once(&self.head).chain(self.tail.iter())
+    }
+
+    /// Sum already-normalized keys into an aggregated normalized key.
+    pub fn sum_normalized_keys(self) -> Result<TypedSecretKey<Normalized>> {
+        let result = self.tail
+            .iter()
+            .try_fold(self.head.key, |acc, item| acc.add_tweak(&(*item.as_inner()).into()))?;
+
+        Ok(TypedSecretKey::from_inner(result))
+    }
+}
+
+/// Build normalized keys from raw `(SecretKey, is_taproot)` pairs.
+pub fn normalize_input_keys<C: Signing>(
+    secp: &Secp256k1<C>,
+    input_keys: &[(SecretKey, bool)],
+) -> Result<NonEmptyNormalizedKeys> {
+    if input_keys.is_empty() {
+        return Err(Error::GenericError("No input provided".to_owned()));
+    }
+
+    let normalized = input_keys
+        .iter()
+        .map(|(key, is_taproot)| TypedSecretKey::new(*key).normalize_for_input(secp, *is_taproot))
+        .collect::<Vec<_>>();
+    NonEmptyNormalizedKeys::from_vec(normalized)
+}
+
+/// Compute the transaction-level partial secret used for output derivation.
 ///
 /// # Arguments
 ///
-/// * `input_keys` - A reference to a list of tuples, each tuple containing a [SecretKey] and [bool]. The [SecretKey] is the private key used in the input, and the [bool] indicates whether this was from a taproot address.
-/// * `outpoints_data` - The prevout outpoints used as input for this transaction. Note that the txid is given in [String] format, which is displayed in reverse order from the inner byte array.
+/// * `secp` - Secp256k1 context used for key arithmetic.
+/// * `input_keys` - Input key metadata as `(SecretKey, is_taproot)` tuples.
+///   Taproot keys are parity-normalized before aggregation.
+/// * `outpoints` - Serialized outpoints used to compute the BIP-352 input hash.
 ///
 /// # Returns
 ///
@@ -19,34 +147,34 @@ use super::hash::calculate_input_hash;
 ///
 /// This function will error if:
 ///
-/// * The input keys array is of length zero, or the summing results in an invalid key.
-/// * The outpoints_data is of length zero, or invalid.
-pub fn calculate_partial_secret(
+/// * `input_keys` is empty, or key aggregation produces an invalid key.
+/// * `outpoints` is empty or cannot be hashed into a valid tweak.
+pub fn calculate_partial_secret<C: Signing>(
+    secp: &Secp256k1<C>,
     input_keys: &[(SecretKey, bool)],
-    outpoints_data: &[(String, u32)],
+    outpoints: &[[u8; OUTPOINTS_LEN]],
 ) -> Result<SecretKey> {
-    let a_sum = get_a_sum_secret_keys(input_keys)?;
+    // First check for empty outpoints
+    let (outpoints_head, outpoints_tail) = outpoints.split_first().ok_or(Error::GenericError("Empty outpoints".to_string()))?;
+    let normalized = normalize_input_keys(secp, input_keys)?;
+    let a_sum = normalized.sum_normalized_keys()?;
 
-    let secp = Secp256k1::signing_only();
-    let A_sum = a_sum.public_key(&secp);
-
-    let input_hash = calculate_input_hash(outpoints_data, A_sum)?;
-
-    Ok(a_sum.mul_tweak(&input_hash)?)
+    a_sum.apply_input_hash(secp, outpoints_head, outpoints_tail)
 }
 
-/// Calculate the shared secret of a transaction.
+/// Compute the ECDH shared secret point for a scan key and partial secret.
 ///
-/// Since [generate_recipient_pubkeys](crate::sending::generate_recipient_pubkeys) calls this function internally, it is not needed for the default sending flow.
+/// [`generate_recipient_pubkeys`](crate::sending::generate_recipient_pubkeys)
+/// expects this result per derivation input.
 ///
 /// # Arguments
 ///
-/// * `B_scan` - The scan public key used by the wallet.
-/// * `partial_secret` - the sum of all (eligible) input keys multiplied with the input hash, see [calculate_partial_secret].
+/// * `B_scan` - Recipient scan public key.
+/// * `partial_secret` - Result from [`calculate_partial_secret`].
 ///
 /// # Returns
 ///
-/// This function returns the shared secret of this transaction. This shared secret can be used to generate output keys for the recipient.
+/// Returns the full public key point `partial_secret * B_scan`.
 pub fn calculate_ecdh_shared_secret(B_scan: &PublicKey, partial_secret: &SecretKey) -> PublicKey {
     let mut ss_bytes = [0u8; 65];
     ss_bytes[0] = 0x04;
@@ -55,32 +183,4 @@ pub fn calculate_ecdh_shared_secret(B_scan: &PublicKey, partial_secret: &SecretK
     ss_bytes[1..].copy_from_slice(&shared_secret_point(B_scan, partial_secret));
 
     PublicKey::from_slice(&ss_bytes).expect("guaranteed to be a point on the curve")
-}
-
-fn get_a_sum_secret_keys(input: &[(SecretKey, bool)]) -> Result<SecretKey> {
-    if input.is_empty() {
-        return Err(Error::GenericError("No input provided".to_owned()));
-    }
-
-    let secp = secp256k1::Secp256k1::new();
-
-    let mut negated_keys: Vec<SecretKey> = vec![];
-
-    for (key, is_taproot) in input {
-        let (_, parity) = key.x_only_public_key(&secp);
-
-        if *is_taproot && parity == secp256k1::Parity::Odd {
-            negated_keys.push(key.negate());
-        } else {
-            negated_keys.push(*key);
-        }
-    }
-
-    let (head, tail) = negated_keys.split_first().expect("input is non-empty");
-
-    let result: SecretKey = tail
-        .iter()
-        .try_fold(*head, |acc, &item| acc.add_tweak(&item.into()))?;
-
-    Ok(result)
 }

--- a/silentpayments/tests/vector_tests.rs
+++ b/silentpayments/tests/vector_tests.rs
@@ -78,7 +78,7 @@ mod tests {
 
             // as an alternative, we could first multiply each input priv key with the input hash
             // that way, we never expose the sk to our library
-            let partial_secret = calculate_partial_secret(&input_priv_keys, &outpoints).unwrap();
+            let partial_secret = calculate_partial_secret(&secp, &input_priv_keys, &outpoints).unwrap();
             let mut inputs: Vec<GeneratePubkeysInput> = Vec::new();
             for addr in silent_addresses {
                 assert!(addr.get_network() == NETWORK);

--- a/silentpayments/tests/vector_tests.rs
+++ b/silentpayments/tests/vector_tests.rs
@@ -2,6 +2,7 @@
 mod common;
 #[cfg(test)]
 mod tests {
+    use bitcoin::{OutPoint, Txid, consensus::serialize};
     use secp256k1::{PublicKey, Scalar, Secp256k1, SecretKey};
     use silentpayments::{
         Network, SilentPaymentAddress, SpVersion, receiving::Label, sending::GeneratePubkeysInput, utils::{
@@ -45,10 +46,10 @@ mod tests {
         for sendingtest in test_case.sending {
             let given = sendingtest.given;
             let expected = sendingtest.expected;
-            let outpoints: Vec<(String, u32)> = given
+            let outpoints: Vec<[u8; 36]> = given
                 .vin
                 .iter()
-                .map(|vin| (vin.txid.clone(), vin.vout))
+                .map(|vin| serialize(&OutPoint::new(Txid::from_str(&vin.txid).unwrap(), vin.vout)).try_into().unwrap())
                 .collect();
             let mut input_priv_keys = Vec::new();
             for input in given.vin {
@@ -127,10 +128,10 @@ mod tests {
 
             let outputs_to_check = decode_outputs_to_check(&given.outputs);
 
-            let outpoints: Vec<(String, u32)> = given
+            let outpoints: Vec<[u8; 36]> = given
                 .vin
                 .iter()
-                .map(|vin| (vin.txid.clone(), vin.vout))
+                .map(|vin| serialize(&OutPoint::new(Txid::from_str(&vin.txid).unwrap(), vin.vout)).try_into().unwrap())
                 .collect();
             let mut input_pub_keys = Vec::new();
             for input in given.vin {
@@ -179,7 +180,9 @@ mod tests {
             // to the expected addresses
             assert_eq!(set1, set2);
 
-            let tweak_data = calculate_tweak_data(&input_pub_keys, &outpoints).unwrap();
+            let (outpoints_head, outpoints_tail) = outpoints.split_first().unwrap();
+
+            let tweak_data = calculate_tweak_data(&secp, &input_pub_keys, outpoints_head, outpoints_tail).unwrap();
             let ecdh_shared_secret = calculate_ecdh_shared_secret(&tweak_data, &b_scan);
 
             let scanned_outputs_received = sp_receiver

--- a/silentpayments/tests/vector_tests.rs
+++ b/silentpayments/tests/vector_tests.rs
@@ -4,14 +4,11 @@ mod common;
 mod tests {
     use secp256k1::{PublicKey, Scalar, Secp256k1, SecretKey};
     use silentpayments::{
-        receiving::Label,
-        utils::{
-            receiving::{
-                calculate_ecdh_shared_secret, calculate_tweak_data, get_pubkey_from_input, is_p2tr,
-            },
-            sending::calculate_partial_secret,
-        },
-        Network, SilentPaymentAddress,
+        Network, SilentPaymentAddress, SpVersion, receiving::Label, sending::GeneratePubkeysInput, utils::{
+            is_p2tr, receiving::{
+                calculate_ecdh_shared_secret, calculate_tweak_data, get_pubkey_from_input,
+            }, sending::calculate_partial_secret
+        }
     };
     use std::{collections::HashSet, io::Cursor, str::FromStr};
 
@@ -28,6 +25,7 @@ mod tests {
     };
 
     const NETWORK: Network = Network::Mainnet;
+    const SPVERSION: SpVersion = SpVersion::ZERO;
 
     #[test]
     fn test_with_test_vectors() {
@@ -80,7 +78,28 @@ mod tests {
             // as an alternative, we could first multiply each input priv key with the input hash
             // that way, we never expose the sk to our library
             let partial_secret = calculate_partial_secret(&input_priv_keys, &outpoints).unwrap();
-            let outputs = generate_recipient_pubkeys(silent_addresses, partial_secret).unwrap();
+            let mut inputs: Vec<GeneratePubkeysInput> = Vec::new();
+            for addr in silent_addresses {
+                assert!(addr.get_network() == NETWORK);
+                let scan_key = addr.get_scan_key();
+                if let Some(input) = inputs.iter_mut().find(|i| i.scan_key == scan_key) {
+                    let spend_key = addr.get_spend_key();
+                    input.spend_keys.push(spend_key);
+                } else {
+                    let ecdh_shared_secret = calculate_ecdh_shared_secret(&scan_key, &partial_secret);
+                    let spend_keys = vec![addr.get_spend_key()];
+                    let sp_version = SPVERSION;
+                    let input = GeneratePubkeysInput {
+                        scan_key: addr.get_scan_key(),
+                        ecdh_shared_secret,
+                        spend_keys,
+                        sp_version,
+                    };
+                    inputs.push(input);
+                }
+            }
+            let outputs = generate_recipient_pubkeys(&secp, inputs, NETWORK).unwrap();
+            assert_ne!(outputs.len(), 0);
 
             for output_pubkeys in &outputs {
                 for pubkey in output_pubkeys.1 {
@@ -104,7 +123,7 @@ mod tests {
             let B_scan = b_scan.public_key(&secp);
 
             let change_label = Label::new(b_scan, 0);
-            let mut sp_receiver = Receiver::new(0, B_scan, B_spend, change_label, NETWORK).unwrap();
+            let mut sp_receiver = Receiver::new(SPVERSION, B_scan, B_spend, change_label, NETWORK).unwrap();
 
             let outputs_to_check = decode_outputs_to_check(&given.outputs);
 

--- a/spdk-wallet/src/client/client.rs
+++ b/spdk-wallet/src/client/client.rs
@@ -39,7 +39,7 @@ impl SpClient {
         };
 
         let sp_receiver = Receiver::new(
-            0,
+            silentpayments::SpVersion::ZERO,
             scan_pubkey,
             (&spend_key).into(),
             change_label,

--- a/spdk-wallet/src/client/spend.rs
+++ b/spdk-wallet/src/client/spend.rs
@@ -6,6 +6,7 @@ use bdk_coin_select::{
     TargetFee, TargetOutputs,
 };
 use bitcoin::absolute::LockTime;
+use bitcoin::consensus::serialize;
 use bitcoin::hashes::Hash;
 use bitcoin::key::TapTweak;
 use bitcoin::script::PushBytesBuf;
@@ -16,6 +17,8 @@ use bitcoin::transaction::Version;
 use bitcoin::{
     Amount, Network, OutPoint, ScriptBuf, Sequence, TapLeafHash, Transaction, TxIn, TxOut, Witness,
 };
+use silentpayments::sending::GeneratePubkeysInput;
+use silentpayments::utils::sending::calculate_ecdh_shared_secret;
 use silentpayments::utils as sp_utils;
 use silentpayments::{Network as SpNetwork, SilentPaymentAddress};
 
@@ -254,6 +257,7 @@ impl SpClient {
     pub fn finalize_transaction(
         mut unsigned_transaction: SilentPaymentUnsignedTransaction,
     ) -> Result<SilentPaymentUnsignedTransaction> {
+        let secp = Secp256k1::signing_only();
         let tx_ins: Vec<TxIn> = unsigned_transaction
             .selected_utxos
             .iter()
@@ -274,9 +278,23 @@ impl SpClient {
             })
             .collect();
 
+        let generate_pubkeys_inputs: Vec<GeneratePubkeysInput> = sp_addresses
+            .into_iter()
+            .map(|sp_address| {
+                let ecdh_shared_secret = calculate_ecdh_shared_secret(&sp_address.get_scan_key(), &unsigned_transaction.partial_secret);
+                GeneratePubkeysInput {
+                    scan_key: sp_address.get_scan_key(),
+                    sp_version: sp_address.get_version().try_into().expect("SilentPaymentAddress type guarantees a valid version"),
+                    spend_keys: vec![sp_address.get_spend_key()],
+                    ecdh_shared_secret
+                }
+            })
+            .collect();
+
         let sp_address2xonlypubkeys = silentpayments::sending::generate_recipient_pubkeys(
-            sp_addresses,
-            unsigned_transaction.partial_secret,
+            &secp,
+            generate_pubkeys_inputs,
+            silentpayments::Network::try_from(unsigned_transaction.network.to_core_arg()).expect("Network type guarantees valid input"),
         )?;
 
         let tx_outs = unsigned_transaction
@@ -438,11 +456,12 @@ impl SpClient {
         &self,
         selected_utxos: &[(OutPoint, DiscoveredOutput)],
     ) -> Result<SecretKey> {
+        let secp = Secp256k1::signing_only();
         let b_spend = self.try_get_secret_spend_key()?;
 
-        let outpoints: Vec<_> = selected_utxos
+        let outpoints: Vec<[u8; 36]> = selected_utxos
             .iter()
-            .map(|(outpoint, _)| (outpoint.txid.to_string(), outpoint.vout))
+            .map(|(outpoint, _)| serialize(&outpoint).try_into().expect("OutPoint type guarantee 36 bytes"))
             .collect();
         let input_privkeys = selected_utxos
             .iter()
@@ -450,7 +469,7 @@ impl SpClient {
             .collect::<Result<Vec<_>>>()?;
 
         let partial_secret =
-            sp_utils::sending::calculate_partial_secret(&input_privkeys, &outpoints)?;
+            sp_utils::sending::calculate_partial_secret(&secp, &input_privkeys, &outpoints)?;
 
         Ok(partial_secret)
     }


### PR DESCRIPTION
Long overdue refactoring of silentpayments crate, some changes were things I wanted to do for a long time, others are made to prepare for the psbt integration.

Most significant ones are:
* f8a674d9316aac069922732eb99679b3b88efd4c and 671467017e803e9be25b3d4d5f2de65f34ec1189 that introduces a new input type to streamline the generation of recipient pubkeys
* ade557b63e0df038bd466d4567f64ba319b36e5a that exposes a public API to "normalize" (i.e. guarantee eveness) of private keys used in inputs spending taproot outputs, which is needed for the psbt workflow. On the same occasion I tried to provide stronger guarantees and guidance for consumer of the library regarding the said normalization of keys after it proved to be a source of confusing bugs while working on psbt.

The rest is mostly incremental improvements that can be discussed case by case.