### PR TITLE
feat: add `SpVersion` type

### DIFF
--- a/silentpayments/examples/create_wallet.rs
+++ b/silentpayments/examples/create_wallet.rs
@@ -7,7 +7,7 @@ use bitcoin::secp256k1::Secp256k1;
 
 // Import types from the silentpayments library
 use silentpayments::receiving::{Label, Receiver};
-use silentpayments::Network;
+use silentpayments::{Network, SpVersion};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Create a new instance of Secp256k1 for cryptographic operations
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Create a new Receiver object with the private and public keys, along with the change label
     let receiver = Receiver::new(
-        0,
+        SpVersion::ZERO,
         scan_privkey.public_key(&secp),
         spend_privkey.public_key(&secp),
         change_label,

--- a/silentpayments/examples/custom_parser.rs
+++ b/silentpayments/examples/custom_parser.rs
@@ -34,9 +34,8 @@ fn main() {
         scan_pubkey,
         spend_pubkey,
         Network::Mainnet,
-        0, // version
-    )
-    .expect("Failed to create address");
+        silentpayments::SpVersion::ZERO,
+    );
 
     println!("Successfully created SilentPaymentAddress without encode feature!");
     println!("Network: {:?}", address.get_network());

--- a/silentpayments/examples/find_output.rs
+++ b/silentpayments/examples/find_output.rs
@@ -8,6 +8,7 @@ use bitcoin::secp256k1::{PublicKey, Secp256k1, XOnlyPublicKey};
 use bitcoin::{Network, PrivateKey, ScriptBuf, Transaction};
 use bitcoin_hashes::hex::FromHex;
 
+use silentpayments::SpVersion;
 // Import types from the silentpayments library
 use silentpayments::receiving::{Label, Receiver};
 use silentpayments::utils::receiving::{
@@ -51,7 +52,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Create a new Receiver object with the private and public keys, along with the change label
     let receiver = Receiver::new(
-        0,
+        SpVersion::ZERO,
         scan_privkey.public_key(&secp),
         spend_privkey.public_key(&secp),
         change_label,

--- a/silentpayments/src/lib.rs
+++ b/silentpayments/src/lib.rs
@@ -53,5 +53,6 @@ pub use secp256k1;
 pub use crate::error::Error;
 pub use utils::common::Network;
 pub use utils::common::SilentPaymentAddress;
+pub use utils::common::SpVersion;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/silentpayments/src/receiving.rs
+++ b/silentpayments/src/receiving.rs
@@ -130,7 +130,7 @@ impl<'de> Deserialize<'de> for Label {
 /// Labels can be added with [`add_label`](Receiver::add_label).
 #[derive(Debug, Clone, PartialEq)]
 pub struct Receiver {
-    version: u8,
+    version: SpVersion,
     scan_pubkey: PublicKey,
     spend_pubkey: PublicKey,
     change_label: Label, // To be able to tell which label is the change
@@ -225,7 +225,7 @@ impl Serialize for Receiver {
         S: serde::Serializer,
     {
         let mut state = serializer.serialize_struct("Receiver", 5)?;
-        state.serialize_field("version", &self.version)?;
+        state.serialize_field::<u8>("version", &self.version.into())?;
         state.serialize_field("network", &self.network)?;
         state.serialize_field(
             "scan_pubkey",
@@ -258,7 +258,7 @@ impl<'de> Deserialize<'de> for Receiver {
     {
         let helper = ReceiverHelper::deserialize(deserializer)?;
         Ok(Receiver {
-            version: helper.version,
+            version: helper.version.try_into().unwrap(),
             network: helper.network,
             scan_pubkey: PublicKey::from_slice(&helper.scan_pubkey.0).unwrap(),
             spend_pubkey: PublicKey::from_slice(&helper.spend_pubkey.0).unwrap(),
@@ -270,7 +270,7 @@ impl<'de> Deserialize<'de> for Receiver {
 
 impl Receiver {
     pub fn new(
-        version: u32,
+        version: SpVersion,
         scan_pubkey: PublicKey,
         spend_pubkey: PublicKey,
         change_label: Label,
@@ -278,15 +278,8 @@ impl Receiver {
     ) -> Result<Self> {
         let labels: BiMap<Label, PublicKey> = BiMap::new();
 
-        // Check version, we just refuse anything other than 0 for now
-        if version != 0 {
-            return Err(Error::GenericError(
-                "Can't have other version than 0 for now".to_owned(),
-            ));
-        }
-
         let mut receiver = Receiver {
-            version: version as u8,
+            version,
             scan_pubkey,
             spend_pubkey,
             change_label: change_label.clone(),
@@ -477,8 +470,7 @@ impl Receiver {
     }
 
     fn get_silent_payment_address(&self, m_pubkey: PublicKey) -> SilentPaymentAddress {
-        SilentPaymentAddress::new(self.scan_pubkey, m_pubkey, self.network, 0)
-            .expect("only fails if version != 0")
+        SilentPaymentAddress::new(self.scan_pubkey, m_pubkey, self.network, self.version)
     }
 }
 

--- a/silentpayments/src/receiving.rs
+++ b/silentpayments/src/receiving.rs
@@ -20,7 +20,7 @@ use crate::{
         common::{calculate_P_n, calculate_t_n},
         hash::LabelHash,
     },
-    Error, Network, Result, SilentPaymentAddress,
+    Error, Network, Result, SilentPaymentAddress, SpVersion,
 };
 use bimap::BiMap;
 use secp256k1::{Parity, PublicKey, Scalar, Secp256k1, SecretKey, XOnlyPublicKey};

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -72,10 +72,36 @@ impl TryFrom<&str> for Network {
     }
 }
 
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum SpVersion {
+    ZERO,
+}
+
+impl From<SpVersion> for u8 {
+    fn from(value: SpVersion) -> Self {
+        match value {
+            SpVersion::ZERO => 0u8,
+        }
+    }
+}
+
+impl TryFrom<u8> for SpVersion {
+    type Error = crate::Error;
+
+    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::ZERO),
+            _ => Err(Error::GenericError(
+                "Unknwon silent payment version".to_string(),
+            )),
+        }
+    }
+}
+
 /// A silent payment address struct that can be used to deserialize a silent payment address string.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct SilentPaymentAddress {
-    version: u8,
+    version: SpVersion,
     scan_pubkey: PublicKey,
     m_pubkey: PublicKey,
     network: Network,
@@ -141,20 +167,14 @@ impl SilentPaymentAddress {
         scan_pubkey: PublicKey,
         m_pubkey: PublicKey,
         network: Network,
-        version: u8,
-    ) -> Result<Self> {
-        if version != 0 {
-            return Err(Error::GenericError(
-                "Can't have other version than 0 for now".to_owned(),
-            ));
-        }
-
-        Ok(SilentPaymentAddress {
+        version: SpVersion,
+    ) -> Self {
+        SilentPaymentAddress {
             scan_pubkey,
             m_pubkey,
             network,
             version,
-        })
+        }
     }
 
     /// Get the scan public key.
@@ -174,7 +194,7 @@ impl SilentPaymentAddress {
 
     /// Get the version byte.
     pub fn get_version(&self) -> u8 {
-        self.version
+        self.version.into()
     }
 }
 
@@ -196,7 +216,7 @@ impl TryFrom<&str> for SilentPaymentAddress {
             return Err(Error::GenericError("Address length is wrong".to_owned()));
         }
 
-        let version = data[0].to_u8();
+        let version: SpVersion = data[0].to_u8().try_into()?;
 
         let network = match hrp.as_str() {
             "sp" => Network::Mainnet,
@@ -215,7 +235,12 @@ impl TryFrom<&str> for SilentPaymentAddress {
         let scan_pubkey = PublicKey::from_slice(&data[..33])?;
         let m_pubkey = PublicKey::from_slice(&data[33..])?;
 
-        SilentPaymentAddress::new(scan_pubkey, m_pubkey, network, version)
+        Ok(SilentPaymentAddress::new(
+            scan_pubkey,
+            m_pubkey,
+            network,
+            version,
+        ))
     }
 }
 
@@ -237,7 +262,7 @@ impl From<SilentPaymentAddress> for String {
             Network::Mainnet => "sp",
         };
 
-        let version = bech32::u5::try_from_u8(val.version).unwrap();
+        let version = bech32::u5::try_from_u8(val.version.into()).unwrap();
 
         let B_scan_bytes = val.scan_pubkey.serialize();
         let B_m_bytes = val.m_pubkey.serialize();

--- a/silentpayments/tests/vector_tests.rs
+++ b/silentpayments/tests/vector_tests.rs
@@ -104,7 +104,14 @@ mod tests {
             let B_scan = b_scan.public_key(&secp);
 
             let change_label = Label::new(b_scan, 0);
-            let mut sp_receiver = Receiver::new(0, B_scan, B_spend, change_label, NETWORK).unwrap();
+            let mut sp_receiver = Receiver::new(
+                silentpayments::SpVersion::ZERO,
+                B_scan,
+                B_spend,
+                change_label,
+                NETWORK,
+            )
+            .unwrap();
 
             let outputs_to_check = decode_outputs_to_check(&given.outputs);
 

--- a/spdk-wallet/src/client/client.rs
+++ b/spdk-wallet/src/client/client.rs
@@ -5,7 +5,7 @@ use bitcoin::{
     secp256k1::{PublicKey, Secp256k1, SecretKey},
 };
 use serde::{Deserialize, Serialize};
-use silentpayments::Network as SpNetwork;
+use silentpayments::{Network as SpNetwork, SpVersion};
 use silentpayments::{
     SilentPaymentAddress,
     bitcoin_hashes::sha256,
@@ -39,7 +39,7 @@ impl SpClient {
         };
 
         let sp_receiver = Receiver::new(
-            0,
+            SpVersion::ZERO,
             scan_pubkey,
             (&spend_key).into(),
             change_label,


### PR DESCRIPTION
Having a proper enum for silent payments versions allow us to simplify some things.