### PR TITLE
feat(silentpayments): add SharedSecret and PartialSecret structs

### DIFF
--- a/silentpayments/src/lib.rs
+++ b/silentpayments/src/lib.rs
@@ -52,6 +52,7 @@ pub use secp256k1;
 
 pub use crate::error::Error;
 pub use utils::common::Network;
+pub use utils::common::SharedSecret;
 pub use utils::common::SilentPaymentAddress;
 pub use utils::common::SpVersion;
 

--- a/silentpayments/src/receiving.rs
+++ b/silentpayments/src/receiving.rs
@@ -17,7 +17,7 @@ use std::{
 
 use crate::{
     utils::{
-        common::{calculate_P_n, calculate_t_n},
+        common::{calculate_P_n, calculate_t_n, SharedSecret},
         hash::LabelHash,
     },
     Error, Network, Result, SilentPaymentAddress, SpVersion,
@@ -362,7 +362,7 @@ impl Receiver {
     ///
     /// # Arguments
     ///
-    /// * `ecdh_shared_secret` -  The ECDH shared secret between sender and recipient as a [PublicKey], the result of elliptic-curve multiplication of `(input_hash * sum_inputs_pubkeys) * scan_private_key`.
+    /// * `ecdh_shared_secret` -  The ECDH shared secret between sender and recipient, the result of elliptic-curve multiplication of `(input_hash * sum_inputs_pubkeys) * scan_private_key`.
     /// * `pubkeys_to_check` - A [HashSet] of public keys of all (unspent) taproot output of the transaction.
     ///
     /// # Returns
@@ -377,7 +377,7 @@ impl Receiver {
     /// * An error occurs during elliptic curve computation. This may happen if a sender is being malicious.
     pub fn scan_transaction(
         &self,
-        ecdh_shared_secret: &PublicKey,
+        ecdh_shared_secret: &SharedSecret,
         pubkeys_to_check: &[XOnlyPublicKey],
     ) -> Result<HashMap<Option<Label>, HashMap<XOnlyPublicKey, Scalar>>> {
         let secp = secp256k1::Secp256k1::new();
@@ -437,7 +437,7 @@ impl Receiver {
     /// * An error occurs during elliptic curve computation. This may happen if a sender is being malicious.
     pub fn get_spks_from_shared_secret(
         &self,
-        ecdh_shared_secret: &PublicKey,
+        ecdh_shared_secret: &SharedSecret,
     ) -> Result<HashMap<Option<Label>, [u8; 34]>> {
         let t_0: SecretKey = calculate_t_n(ecdh_shared_secret, 0)?;
         let P_0: PublicKey = calculate_P_n(&self.spend_pubkey, t_0.into())?;

--- a/silentpayments/src/sending.rs
+++ b/silentpayments/src/sending.rs
@@ -8,11 +8,13 @@
 //! See the [tests on github](https://github.com/cygnet3/rust-silentpayments/blob/master/tests/vector_tests.rs)
 //! for a concrete example.
 
-use secp256k1::{PublicKey, Secp256k1, SecretKey, XOnlyPublicKey};
+use secp256k1::{PublicKey, Secp256k1, XOnlyPublicKey};
 use std::collections::HashMap;
 
 use crate::utils::common::calculate_t_n;
+use crate::utils::common::SharedSecret;
 use crate::utils::sending::calculate_ecdh_shared_secret;
+use crate::utils::sending::PartialSecret;
 use crate::Result;
 use crate::SilentPaymentAddress;
 
@@ -40,11 +42,11 @@ use crate::SilentPaymentAddress;
 /// * Edge cases are hit during elliptic curve computation (extremely unlikely).
 pub fn generate_recipient_pubkeys(
     recipients: Vec<SilentPaymentAddress>,
-    partial_secret: SecretKey,
+    partial_secret: PartialSecret,
 ) -> Result<HashMap<SilentPaymentAddress, Vec<XOnlyPublicKey>>> {
     let secp = Secp256k1::new();
 
-    let mut silent_payment_groups: HashMap<PublicKey, (PublicKey, Vec<SilentPaymentAddress>)> =
+    let mut silent_payment_groups: HashMap<PublicKey, (SharedSecret, Vec<SilentPaymentAddress>)> =
         HashMap::new();
     for address in recipients {
         let B_scan = address.get_scan_key();

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -20,7 +20,11 @@ use serde::Deserializer;
 use serde::{Deserialize, Serialize};
 
 #[cfg(any(feature = "sending", feature = "receiving"))]
-pub(crate) fn calculate_t_n(ecdh_shared_secret: &PublicKey, k: u32) -> Result<SecretKey> {
+#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
+pub struct SharedSecret(pub(crate) PublicKey);
+
+#[cfg(any(feature = "sending", feature = "receiving"))]
+pub(crate) fn calculate_t_n(ecdh_shared_secret: &SharedSecret, k: u32) -> Result<SecretKey> {
     let hash = SharedSecretHash::from_ecdh_and_k(ecdh_shared_secret, k).to_byte_array();
     let sk = SecretKey::from_slice(&hash)?;
 

--- a/silentpayments/src/utils/hash.rs
+++ b/silentpayments/src/utils/hash.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::{utils::common::SharedSecret, Error};
 use bitcoin_hashes::{sha256t_hash_newtype, Hash, HashEngine};
 use secp256k1::{PublicKey, Scalar, SecretKey};
 
@@ -59,9 +59,9 @@ impl LabelHash {
 }
 
 impl SharedSecretHash {
-    pub(crate) fn from_ecdh_and_k(ecdh: &PublicKey, k: u32) -> SharedSecretHash {
+    pub(crate) fn from_ecdh_and_k(ecdh: &SharedSecret, k: u32) -> SharedSecretHash {
         let mut eng = SharedSecretHash::engine();
-        eng.input(&ecdh.serialize());
+        eng.input(&ecdh.0.serialize());
         eng.input(&k.to_be_bytes());
         SharedSecretHash::from_engine(eng)
     }

--- a/silentpayments/src/utils/receiving.rs
+++ b/silentpayments/src/utils/receiving.rs
@@ -1,8 +1,8 @@
 //! Receiving utility functions.
 use crate::{
     utils::{
-        OP_0, OP_1, OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160, OP_PUSHBYTES_20,
-        OP_PUSHBYTES_32,
+        common::SharedSecret, OP_0, OP_1, OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY,
+        OP_HASH160, OP_PUSHBYTES_20, OP_PUSHBYTES_32,
     },
     Error, Result,
 };
@@ -54,14 +54,14 @@ pub fn calculate_tweak_data(
 /// # Returns
 ///
 /// This function returns the shared secret of this transaction. This shared secret can be used to scan the transaction of outputs that are for the current user. See [`Receiver::scan_transaction`](crate::receiving::Receiver::scan_transaction).
-pub fn calculate_ecdh_shared_secret(tweak_data: &PublicKey, b_scan: &SecretKey) -> PublicKey {
+pub fn calculate_ecdh_shared_secret(tweak_data: &PublicKey, b_scan: &SecretKey) -> SharedSecret {
     let mut ss_bytes = [0u8; 65];
     ss_bytes[0] = 0x04;
 
     // Using `shared_secret_point` to ensure the multiplication is constant time
-    ss_bytes[1..].copy_from_slice(&shared_secret_point(&tweak_data, &b_scan));
+    ss_bytes[1..].copy_from_slice(&shared_secret_point(tweak_data, b_scan));
 
-    PublicKey::from_slice(&ss_bytes).expect("guaranteed to be a point on the curve")
+    SharedSecret(PublicKey::from_slice(&ss_bytes).expect("guaranteed to be a point on the curve"))
 }
 
 /// Get the public keys from a set of input data.

--- a/silentpayments/src/utils/sending.rs
+++ b/silentpayments/src/utils/sending.rs
@@ -1,8 +1,26 @@
 //! Sending utility functions.
-use crate::{Error, Result};
-use secp256k1::{ecdh::shared_secret_point, PublicKey, Secp256k1, SecretKey};
+use crate::{utils::common::SharedSecret, Error, Result};
+use secp256k1::constants::SECRET_KEY_SIZE;
+use secp256k1::ecdh::shared_secret_point;
+use secp256k1::{PublicKey, Secp256k1, SecretKey};
 
 use super::hash::calculate_input_hash;
+
+/// Represents the sum of all eligible public keys multiplied with the input hash
+#[derive(Clone, Copy, Debug)]
+pub struct PartialSecret(pub(crate) SecretKey);
+
+impl PartialSecret {
+    /// Re-construct the partial secret from the inner bytes.
+    pub fn from_slice(data: &[u8]) -> Result<Self> {
+        Ok(Self(SecretKey::from_slice(data)?))
+    }
+
+    /// Returns the inner bytes of the partial secret
+    pub fn secret_bytes(&self) -> [u8; SECRET_KEY_SIZE] {
+        self.0.secret_bytes()
+    }
+}
 
 /// Calculate the partial secret that is needed for generating the recipient pubkeys.
 ///
@@ -24,7 +42,7 @@ use super::hash::calculate_input_hash;
 pub fn calculate_partial_secret(
     input_keys: &[(SecretKey, bool)],
     outpoints_data: &[(String, u32)],
-) -> Result<SecretKey> {
+) -> Result<PartialSecret> {
     let a_sum = get_a_sum_secret_keys(input_keys)?;
 
     let secp = Secp256k1::signing_only();
@@ -32,7 +50,7 @@ pub fn calculate_partial_secret(
 
     let input_hash = calculate_input_hash(outpoints_data, A_sum)?;
 
-    Ok(a_sum.mul_tweak(&input_hash)?)
+    Ok(PartialSecret(a_sum.mul_tweak(&input_hash)?))
 }
 
 /// Calculate the shared secret of a transaction.
@@ -46,15 +64,18 @@ pub fn calculate_partial_secret(
 ///
 /// # Returns
 ///
-/// This function returns the shared secret of this transaction. This shared secret can be used to generate output keys for the recipient.
-pub fn calculate_ecdh_shared_secret(B_scan: &PublicKey, partial_secret: &SecretKey) -> PublicKey {
+/// This function returns the shared secret unique to this recipient and input keys. This shared secret can be used to generate output keys for the recipient.
+pub fn calculate_ecdh_shared_secret(
+    B_scan: &PublicKey,
+    partial_secret: &PartialSecret,
+) -> SharedSecret {
     let mut ss_bytes = [0u8; 65];
     ss_bytes[0] = 0x04;
 
     // Using `shared_secret_point` to ensure the multiplication is constant time
-    ss_bytes[1..].copy_from_slice(&shared_secret_point(B_scan, partial_secret));
+    ss_bytes[1..].copy_from_slice(&shared_secret_point(B_scan, &partial_secret.0));
 
-    PublicKey::from_slice(&ss_bytes).expect("guaranteed to be a point on the curve")
+    SharedSecret(PublicKey::from_slice(&ss_bytes).expect("guaranteed to be a point on the curve"))
 }
 
 fn get_a_sum_secret_keys(input: &[(SecretKey, bool)]) -> Result<SecretKey> {

--- a/spdk-wallet/src/client/client.rs
+++ b/spdk-wallet/src/client/client.rs
@@ -5,7 +5,7 @@ use bitcoin::{
     secp256k1::{PublicKey, Secp256k1, SecretKey},
 };
 use serde::{Deserialize, Serialize};
-use silentpayments::{Network as SpNetwork, SpVersion};
+use silentpayments::{Network as SpNetwork, SharedSecret, SpVersion};
 use silentpayments::{
     SilentPaymentAddress,
     bitcoin_hashes::sha256,
@@ -80,7 +80,7 @@ impl SpClient {
     pub fn get_script_to_secret_map(
         &self,
         tweak_data_vec: Vec<PublicKey>,
-    ) -> Result<HashMap<[u8; 34], PublicKey>> {
+    ) -> Result<HashMap<[u8; 34], SharedSecret>> {
         // if using rayon feature, import the preludes
         #[cfg(feature = "rayon")]
         use rayon::prelude::*;

--- a/spdk-wallet/src/client/spend.rs
+++ b/spdk-wallet/src/client/spend.rs
@@ -9,7 +9,7 @@ use bitcoin::absolute::LockTime;
 use bitcoin::hashes::Hash;
 use bitcoin::key::TapTweak;
 use bitcoin::script::PushBytesBuf;
-use bitcoin::secp256k1::{Keypair, Message, Secp256k1, SecretKey};
+use bitcoin::secp256k1::{Keypair, Message, Secp256k1};
 use bitcoin::sighash::{Prevouts, SighashCache};
 use bitcoin::taproot::Signature;
 use bitcoin::transaction::Version;
@@ -17,6 +17,7 @@ use bitcoin::{
     Amount, Network, OutPoint, ScriptBuf, Sequence, TapLeafHash, Transaction, TxIn, TxOut, Witness,
 };
 use silentpayments::utils as sp_utils;
+use silentpayments::utils::sending::PartialSecret;
 use silentpayments::{Network as SpNetwork, SilentPaymentAddress};
 
 use spdk_core::constants::{DATA_CARRIER_SIZE, NUMS};
@@ -437,7 +438,7 @@ impl SpClient {
     pub fn get_partial_secret_for_selected_utxos(
         &self,
         selected_utxos: &[(OutPoint, DiscoveredOutput)],
-    ) -> Result<SecretKey> {
+    ) -> Result<PartialSecret> {
         let b_spend = self.try_get_secret_spend_key()?;
 
         let outpoints: Vec<_> = selected_utxos

--- a/spdk-wallet/src/client/structs.rs
+++ b/spdk-wallet/src/client/structs.rs
@@ -8,6 +8,7 @@ use bitcoin::secp256k1::{PublicKey, SecretKey};
 use bitcoin::{Address, Amount, Network, OutPoint, Transaction};
 use serde::{Deserialize, Serialize};
 use silentpayments::SilentPaymentAddress;
+use silentpayments::utils::sending::PartialSecret;
 
 use spdk_core::updater::DiscoveredOutput;
 
@@ -58,7 +59,7 @@ pub struct Recipient {
 pub struct SilentPaymentUnsignedTransaction {
     pub selected_utxos: Vec<(OutPoint, DiscoveredOutput)>,
     pub recipients: Vec<Recipient>,
-    pub partial_secret: SecretKey,
+    pub partial_secret: PartialSecret,
     pub unsigned_tx: Option<Transaction>,
     pub network: Network,
 }

--- a/spdk-wallet/src/scanner/scanner.rs
+++ b/spdk-wallet/src/scanner/scanner.rs
@@ -15,7 +15,7 @@ use bitcoin::{
 };
 use futures::{Stream, StreamExt, pin_mut};
 use log::info;
-use silentpayments::receiving::Label;
+use silentpayments::{SharedSecret, receiving::Label};
 
 use spdk_core::chain::{BlockData, ChainBackend, FilterData, UtxoData};
 use spdk_core::updater::{DiscoveredOutput, Updater};
@@ -221,7 +221,7 @@ impl<'a> SpScanner<'a> {
     async fn scan_utxos(
         &self,
         blkheight: Height,
-        secrets_map: HashMap<[u8; 34], PublicKey>,
+        secrets_map: HashMap<[u8; 34], SharedSecret>,
     ) -> Result<Vec<(Option<Label>, UtxoData, Scalar)>> {
         let utxos = self.backend.utxos(blkheight).await?;
 


### PR DESCRIPTION
Instead of using the PublicKey/SecretKey structs from the secp library directly, use some custom structs in our public api that represent these higher-level concepts.

This should make it more difficult to end-users of this crate to accidentally insert the wrong key material.