### PR TITLE
feat(silentpayments): add custom outpoint struct

### DIFF
--- a/silentpayments/examples/find_output.rs
+++ b/silentpayments/examples/find_output.rs
@@ -8,6 +8,7 @@ use bitcoin::secp256k1::{PublicKey, Secp256k1, XOnlyPublicKey};
 use bitcoin::{Network, PrivateKey, ScriptBuf, Transaction};
 use bitcoin_hashes::hex::FromHex;
 
+use silentpayments::utils::OutPoint;
 use silentpayments::SpVersion;
 // Import types from the silentpayments library
 use silentpayments::receiving::{Label, Receiver};
@@ -60,12 +61,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     )?;
 
     // Extract outpoints (previous transaction outputs) from the transaction inputs and store them in a vector
-    let outpoints: Vec<(String, u32)> = tx
+    let outpoints: Vec<OutPoint> = tx
         .input
         .iter()
         .map(|i| {
-            let outpoint = i.previous_output;
-            (outpoint.txid.to_string(), outpoint.vout)
+            let prevout = i.previous_output;
+            OutPoint::from_txid_and_vout(prevout.txid.to_string(), prevout.vout).unwrap()
         })
         .collect();
 

--- a/silentpayments/src/utils.rs
+++ b/silentpayments/src/utils.rs
@@ -11,6 +11,9 @@ pub mod sending;
 
 pub(crate) mod common;
 
+#[cfg(any(feature = "sending", feature = "receiving"))]
+pub use common::OutPoint;
+
 /// [BIP341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki)-defined 'Nothing Up My Sleeve' point.
 pub const NUMS_H: [u8; 32] = [
     0x50, 0x92, 0x9b, 0x74, 0xc1, 0xa0, 0x49, 0x54, 0xb7, 0x8b, 0x4b, 0x60, 0x35, 0xe9, 0x7a, 0x5e,

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -327,3 +327,29 @@ impl From<SilentPaymentAddress> for String {
         bech32::encode(hrp, data, bech32::Variant::Bech32m).unwrap()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use bitcoin::consensus::serialize;
+
+    use crate::utils;
+
+    #[test]
+    fn outpoint_parsing_equivalence() {
+        // example outpoint from genesis block
+        let txid = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+        let vout = 0;
+
+        let sp_outpoint_from_txid_and_vout =
+            utils::OutPoint::from_txid_and_vout(txid.to_string(), vout).unwrap();
+
+        let outpoint = bitcoin::OutPoint::from_str(&format!("{txid}:{vout}")).unwrap();
+        // consensus serialization of bitcoin outpoint struct to byte array
+        let outpoint_bytes: [u8; 36] = serialize(&outpoint).try_into().unwrap();
+        let sp_outpoint_from_bytes = utils::OutPoint::from_bytes(outpoint_bytes);
+
+        assert_eq!(sp_outpoint_from_txid_and_vout, sp_outpoint_from_bytes);
+    }
+}

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -20,6 +20,54 @@ use serde::Deserializer;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+/// Struct representing an OutPoint type.
+///
+/// This can be constructed from a rust-bitcoin outpoint:
+/// ```
+/// use silentpayments::utils::OutPoint;
+/// use bitcoin::consensus::serialize;
+/// # use std::str::FromStr;
+///
+/// # let bitcoin_outpoint = bitcoin::OutPoint::from_str(&format!("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f:0")).unwrap();
+/// let serialized: [u8; 36] = serialize(&bitcoin_outpoint).try_into().unwrap();
+/// let outpoint = OutPoint::from_bytes(serialized);
+/// ```
+#[cfg(any(feature = "sending", feature = "receiving"))]
+#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
+pub struct OutPoint(pub(crate) [u8; 36]);
+
+impl OutPoint {
+    /// Parse outpoin from a [String] txid and [u32] vout.
+    /// This may fail if the txid is not a valid 32 byte hex string.
+    pub fn from_txid_and_vout(txid: String, vout: u32) -> Result<Self> {
+        let mut bytes: Vec<u8> = hex::decode(&txid)?;
+
+        if bytes.len() != 32 {
+            return Err(Error::GenericError(format!(
+                "Invalid outpoint hex representation: {}",
+                txid
+            )));
+        }
+
+        // txid in string format is big endian and we need little endian
+        bytes.reverse();
+
+        let mut buffer = [0u8; 36];
+
+        buffer[..32].copy_from_slice(&bytes);
+        buffer[32..].copy_from_slice(&vout.to_le_bytes());
+        Ok(Self(buffer))
+    }
+
+    pub fn from_bytes(bytes: [u8; 36]) -> Self {
+        Self(bytes)
+    }
+
+    pub fn to_bytes(&self) -> [u8; 36] {
+        self.0
+    }
+}
+
 #[cfg(any(feature = "sending", feature = "receiving"))]
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct SharedSecret(pub(crate) PublicKey);

--- a/silentpayments/src/utils/hash.rs
+++ b/silentpayments/src/utils/hash.rs
@@ -1,4 +1,7 @@
-use crate::{utils::common::SharedSecret, Error};
+use crate::{
+    utils::common::{OutPoint, SharedSecret},
+    Error,
+};
 use bitcoin_hashes::{sha256t_hash_newtype, Hash, HashEngine};
 use secp256k1::{PublicKey, Scalar, SecretKey};
 
@@ -30,11 +33,11 @@ sha256t_hash_newtype! {
 
 impl InputsHash {
     pub(crate) fn from_outpoint_and_A_sum(
-        smallest_outpoint: &[u8; 36],
+        smallest_outpoint: &OutPoint,
         A_sum: PublicKey,
     ) -> InputsHash {
         let mut eng = InputsHash::engine();
-        eng.input(smallest_outpoint);
+        eng.input(&smallest_outpoint.0);
         eng.input(&A_sum.serialize());
         InputsHash::from_engine(eng)
     }
@@ -68,45 +71,15 @@ impl SharedSecretHash {
 }
 
 pub(crate) fn calculate_input_hash(
-    outpoints_data: &[(String, u32)],
+    outpoints_data: &[OutPoint],
     A_sum: PublicKey,
 ) -> Result<Scalar, Error> {
     if outpoints_data.is_empty() {
         return Err(Error::GenericError("No outpoints provided".to_owned()));
     }
-
-    let mut outpoints: Vec<[u8; 36]> = Vec::with_capacity(outpoints_data.len());
-
-    // should probably just use an OutPoints type properly at some point
-    for (txid, vout) in outpoints_data {
-        let mut bytes: Vec<u8> = hex::decode(txid.as_str())?;
-
-        if bytes.len() != 32 {
-            return Err(Error::GenericError(format!(
-                "Invalid outpoint hex representation: {}",
-                txid
-            )));
-        }
-
-        // txid in string format is big endian and we need little endian
-        bytes.reverse();
-
-        let mut buffer = [0u8; 36];
-
-        buffer[..32].copy_from_slice(&bytes);
-        buffer[32..].copy_from_slice(&vout.to_le_bytes());
-        outpoints.push(buffer);
-    }
-
-    // sort outpoints
-    outpoints.sort_unstable();
-
-    if let Some(smallest_outpoint) = outpoints.first() {
-        Ok(InputsHash::from_outpoint_and_A_sum(smallest_outpoint, A_sum).to_scalar())
-    } else {
-        // This should never happen
-        Err(Error::GenericError(
-            "Unexpected empty outpoints vector".to_owned(),
-        ))
-    }
+    let smallest_outpoint = outpoints_data
+        .iter()
+        .min()
+        .expect("must be present if array is non-empty");
+    Ok(InputsHash::from_outpoint_and_A_sum(smallest_outpoint, A_sum).to_scalar())
 }

--- a/silentpayments/src/utils/receiving.rs
+++ b/silentpayments/src/utils/receiving.rs
@@ -1,8 +1,9 @@
 //! Receiving utility functions.
 use crate::{
     utils::{
-        common::SharedSecret, OP_0, OP_1, OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY,
-        OP_HASH160, OP_PUSHBYTES_20, OP_PUSHBYTES_32,
+        common::{OutPoint, SharedSecret},
+        OP_0, OP_1, OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160, OP_PUSHBYTES_20,
+        OP_PUSHBYTES_32,
     },
     Error, Result,
 };
@@ -35,7 +36,7 @@ use super::{hash::calculate_input_hash, COMPRESSED_PUBKEY_SIZE, NUMS_H};
 /// * Elliptic curve computation results in an invalid public key.
 pub fn calculate_tweak_data(
     input_pub_keys: &[&PublicKey],
-    outpoints_data: &[(String, u32)],
+    outpoints_data: &[OutPoint],
 ) -> Result<PublicKey> {
     let secp = secp256k1::Secp256k1::verification_only();
     let A_sum = PublicKey::combine_keys(input_pub_keys)?;

--- a/silentpayments/src/utils/sending.rs
+++ b/silentpayments/src/utils/sending.rs
@@ -1,4 +1,5 @@
 //! Sending utility functions.
+use crate::utils::common::OutPoint;
 use crate::{utils::common::SharedSecret, Error, Result};
 use secp256k1::constants::SECRET_KEY_SIZE;
 use secp256k1::ecdh::shared_secret_point;
@@ -41,7 +42,7 @@ impl PartialSecret {
 /// * The outpoints_data is of length zero, or invalid.
 pub fn calculate_partial_secret(
     input_keys: &[(SecretKey, bool)],
-    outpoints_data: &[(String, u32)],
+    outpoints_data: &[OutPoint],
 ) -> Result<PartialSecret> {
     let a_sum = get_a_sum_secret_keys(input_keys)?;
 

--- a/silentpayments/tests/vector_tests.rs
+++ b/silentpayments/tests/vector_tests.rs
@@ -10,6 +10,7 @@ mod tests {
                 calculate_ecdh_shared_secret, calculate_tweak_data, get_pubkey_from_input, is_p2tr,
             },
             sending::calculate_partial_secret,
+            OutPoint,
         },
         Network, SilentPaymentAddress,
     };
@@ -47,10 +48,10 @@ mod tests {
         for sendingtest in test_case.sending {
             let given = sendingtest.given;
             let expected = sendingtest.expected;
-            let outpoints: Vec<(String, u32)> = given
+            let outpoints: Vec<OutPoint> = given
                 .vin
                 .iter()
-                .map(|vin| (vin.txid.clone(), vin.vout))
+                .map(|vin| OutPoint::from_txid_and_vout(vin.txid.clone(), vin.vout).unwrap())
                 .collect();
             let mut input_priv_keys = Vec::new();
             for input in given.vin {
@@ -115,10 +116,10 @@ mod tests {
 
             let outputs_to_check = decode_outputs_to_check(&given.outputs);
 
-            let outpoints: Vec<(String, u32)> = given
+            let outpoints: Vec<OutPoint> = given
                 .vin
                 .iter()
-                .map(|vin| (vin.txid.clone(), vin.vout))
+                .map(|vin| OutPoint::from_txid_and_vout(vin.txid.clone(), vin.vout).unwrap())
                 .collect();
             let mut input_pub_keys = Vec::new();
             for input in given.vin {

--- a/spdk-wallet/src/client/spend.rs
+++ b/spdk-wallet/src/client/spend.rs
@@ -441,10 +441,15 @@ impl SpClient {
     ) -> Result<PartialSecret> {
         let b_spend = self.try_get_secret_spend_key()?;
 
-        let outpoints: Vec<_> = selected_utxos
+        let outpoints = selected_utxos
             .iter()
-            .map(|(outpoint, _)| (outpoint.txid.to_string(), outpoint.vout))
-            .collect();
+            .map(|(outpoint, _)| {
+                Ok(sp_utils::OutPoint::from_txid_and_vout(
+                    outpoint.txid.to_string(),
+                    outpoint.vout,
+                )?)
+            })
+            .collect::<Result<Vec<sp_utils::OutPoint>>>()?;
         let input_privkeys = selected_utxos
             .iter()
             .map(|(_, output)| Ok((b_spend.add_tweak(&output.tweak)?, true)))


### PR DESCRIPTION
Add a custom struct that represents an outpoint to the silentpayments crate api.