### PR TITLE
refactor(silentpayments): make calculate_input_hash infallible

### DIFF
--- a/silentpayments/src/error.rs
+++ b/silentpayments/src/error.rs
@@ -11,6 +11,7 @@ pub enum Error {
     Secp256k1Error(secp256k1::Error),
     OutOfRangeError(secp256k1::scalar::OutOfRangeError),
     IOError(std::io::Error),
+    EmptyArray,
 }
 
 impl fmt::Display for Error {
@@ -25,6 +26,7 @@ impl fmt::Display for Error {
             Error::Secp256k1Error(e) => e.fmt(f),
             Error::OutOfRangeError(e) => e.fmt(f),
             Error::IOError(e) => e.fmt(f),
+            Error::EmptyArray => write!(f, "Non-empty array required"),
         }
     }
 }

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -328,6 +328,30 @@ impl From<SilentPaymentAddress> for String {
     }
 }
 
+pub(crate) struct NonEmptyArray<'a, T>(&'a [T]);
+
+impl<'a, T> NonEmptyArray<'a, T> {
+    pub fn new(arr: &'a [T]) -> crate::Result<Self> {
+        match !arr.is_empty() {
+            true => Ok(Self(arr)),
+            false => Err(crate::Error::EmptyArray),
+        }
+    }
+
+    pub fn as_inner(&'a self) -> &'a [T] {
+        self.0
+    }
+}
+
+impl<'a, T> NonEmptyArray<'a, T>
+where
+    T: Ord,
+{
+    pub fn min(&'a self) -> &'a T {
+        self.0.iter().min().expect("Is non-empty")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;

--- a/silentpayments/src/utils/hash.rs
+++ b/silentpayments/src/utils/hash.rs
@@ -1,7 +1,4 @@
-use crate::{
-    utils::common::{OutPoint, SharedSecret},
-    Error,
-};
+use crate::utils::common::{NonEmptyArray, OutPoint, SharedSecret};
 use bitcoin_hashes::{sha256t_hash_newtype, Hash, HashEngine};
 use secp256k1::{PublicKey, Scalar, SecretKey};
 
@@ -71,15 +68,8 @@ impl SharedSecretHash {
 }
 
 pub(crate) fn calculate_input_hash(
-    outpoints_data: &[OutPoint],
+    outpoints_data: NonEmptyArray<OutPoint>,
     A_sum: PublicKey,
-) -> Result<Scalar, Error> {
-    if outpoints_data.is_empty() {
-        return Err(Error::GenericError("No outpoints provided".to_owned()));
-    }
-    let smallest_outpoint = outpoints_data
-        .iter()
-        .min()
-        .expect("must be present if array is non-empty");
-    Ok(InputsHash::from_outpoint_and_A_sum(smallest_outpoint, A_sum).to_scalar())
+) -> Scalar {
+    InputsHash::from_outpoint_and_A_sum(outpoints_data.min(), A_sum).to_scalar()
 }

--- a/silentpayments/src/utils/receiving.rs
+++ b/silentpayments/src/utils/receiving.rs
@@ -1,7 +1,7 @@
 //! Receiving utility functions.
 use crate::{
     utils::{
-        common::{OutPoint, SharedSecret},
+        common::{NonEmptyArray, OutPoint, SharedSecret},
         OP_0, OP_1, OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160, OP_PUSHBYTES_20,
         OP_PUSHBYTES_32,
     },
@@ -40,7 +40,9 @@ pub fn calculate_tweak_data(
 ) -> Result<PublicKey> {
     let secp = secp256k1::Secp256k1::verification_only();
     let A_sum = PublicKey::combine_keys(input_pub_keys)?;
-    let input_hash = calculate_input_hash(outpoints_data, A_sum)?;
+
+    let outpoints = NonEmptyArray::new(outpoints_data)?;
+    let input_hash = calculate_input_hash(outpoints, A_sum);
 
     Ok(A_sum.mul_tweak(&secp, &input_hash)?)
 }

--- a/silentpayments/src/utils/sending.rs
+++ b/silentpayments/src/utils/sending.rs
@@ -1,5 +1,5 @@
 //! Sending utility functions.
-use crate::utils::common::OutPoint;
+use crate::utils::common::{NonEmptyArray, OutPoint};
 use crate::{utils::common::SharedSecret, Error, Result};
 use secp256k1::constants::SECRET_KEY_SIZE;
 use secp256k1::ecdh::shared_secret_point;
@@ -49,7 +49,8 @@ pub fn calculate_partial_secret(
     let secp = Secp256k1::signing_only();
     let A_sum = a_sum.public_key(&secp);
 
-    let input_hash = calculate_input_hash(outpoints_data, A_sum)?;
+    let outpoints = NonEmptyArray::new(outpoints_data)?;
+    let input_hash = calculate_input_hash(outpoints, A_sum);
 
     Ok(PartialSecret(a_sum.mul_tweak(&input_hash)?))
 }


### PR DESCRIPTION
Use a new NonEmptyArray struct to make this function infallible