### PR TITLE
Refactor/sp address use raw bytes

### DIFF
--- a/silentpayments/examples/custom_parser.rs
+++ b/silentpayments/examples/custom_parser.rs
@@ -37,10 +37,10 @@ fn main() {
     );
 
     println!("Successfully created SilentPaymentAddress without encode feature!");
-    println!("Network: {:?}", address.get_network());
-    println!("Version: {}", address.get_version());
-    println!("Scan key: {:?}", address.get_scan_key());
-    println!("Spend key: {:?}", address.get_spend_key());
+    println!("Network: {:?}", address.network());
+    println!("Version: {}", u8::from(address.version()));
+    println!("Scan key: {:?}", address.scan_key());
+    println!("Spend key: {:?}", address.spend_key());
 
     println!("\n✅ This example compiled and ran with ZERO features enabled!");
     println!("   Only dependencies: secp256k1, rand, rand_core, secp256k1-sys");

--- a/silentpayments/src/lib.rs
+++ b/silentpayments/src/lib.rs
@@ -55,6 +55,7 @@ pub use utils::common::Network;
 #[cfg(any(feature = "sending", feature = "receiving"))]
 pub use utils::common::SharedSecret;
 pub use utils::common::SilentPaymentAddress;
+pub use utils::common::SilentPaymentAddressRaw;
 pub use utils::common::SpVersion;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/silentpayments/src/sending.rs
+++ b/silentpayments/src/sending.rs
@@ -13,10 +13,10 @@ use std::collections::HashMap;
 
 use crate::utils::common::calculate_t_n;
 use crate::utils::common::SharedSecret;
+use crate::utils::common::SilentPaymentAddressRaw;
 use crate::utils::sending::calculate_ecdh_shared_secret;
 use crate::utils::sending::PartialSecret;
 use crate::Result;
-use crate::SilentPaymentAddress;
 
 /// Create outputs for a given set of silent payment recipients and their corresponding shared secrets.
 ///
@@ -26,7 +26,7 @@ use crate::SilentPaymentAddress;
 ///
 /// # Arguments
 ///
-/// * `recipients` - A [Vec] of silent payment addresses strings to be paid.
+/// * `recipients` - A [Vec] of silent payment addresses to be paid.
 /// * `partial_secret` - [PartialSecret] that represents the sum of the private keys of eligible inputs of the transaction multiplied by the input hash.
 ///
 /// # Returns
@@ -38,29 +38,31 @@ use crate::SilentPaymentAddress;
 ///
 /// This function will return an error if:
 ///
-/// * The recipients [Vec] contains a silent payment address with an incorrect format.
 /// * Edge cases are hit during elliptic curve computation (extremely unlikely).
 pub fn generate_recipient_pubkeys(
-    recipients: Vec<SilentPaymentAddress>,
+    recipients: Vec<SilentPaymentAddressRaw>,
     partial_secret: PartialSecret,
-) -> Result<HashMap<SilentPaymentAddress, Vec<XOnlyPublicKey>>> {
+) -> Result<HashMap<SilentPaymentAddressRaw, Vec<XOnlyPublicKey>>> {
     let secp = Secp256k1::new();
 
-    let mut silent_payment_groups: HashMap<PublicKey, (SharedSecret, Vec<SilentPaymentAddress>)> =
-        HashMap::new();
+    let mut silent_payment_groups: HashMap<
+        PublicKey,
+        (SharedSecret, Vec<SilentPaymentAddressRaw>),
+    > = HashMap::new();
     for address in recipients {
-        let B_scan = address.get_scan_key();
+        let recipient_scan_key = address.scan_key();
 
-        if let Some((_, payments)) = silent_payment_groups.get_mut(&B_scan) {
+        if let Some((_, payments)) = silent_payment_groups.get_mut(&recipient_scan_key) {
             payments.push(address);
         } else {
-            let ecdh_shared_secret = calculate_ecdh_shared_secret(&B_scan, &partial_secret);
+            let ecdh_shared_secret =
+                calculate_ecdh_shared_secret(&recipient_scan_key, &partial_secret);
 
-            silent_payment_groups.insert(B_scan, (ecdh_shared_secret, vec![address]));
+            silent_payment_groups.insert(recipient_scan_key, (ecdh_shared_secret, vec![address]));
         }
     }
 
-    let mut result: HashMap<SilentPaymentAddress, Vec<XOnlyPublicKey>> = HashMap::new();
+    let mut result: HashMap<SilentPaymentAddressRaw, Vec<XOnlyPublicKey>> = HashMap::new();
     for group in silent_payment_groups.into_values() {
         let (ecdh_shared_secret, recipients) = group;
 
@@ -68,7 +70,7 @@ pub fn generate_recipient_pubkeys(
             let t_n = calculate_t_n(&ecdh_shared_secret, n as u32)?;
 
             let res = t_n.public_key(&secp);
-            let reskey = res.combine(&addr.get_spend_key())?;
+            let reskey = res.combine(&addr.spend_key())?;
             let (reskey_xonly, _) = reskey.x_only_public_key();
 
             let entry = result.entry(addr).or_default();

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -416,9 +416,10 @@ pub(crate) struct NonEmptyArray<'a, T>(&'a [T]);
 
 impl<'a, T> NonEmptyArray<'a, T> {
     pub fn new(arr: &'a [T]) -> crate::Result<Self> {
-        match !arr.is_empty() {
-            true => Ok(Self(arr)),
-            false => Err(crate::Error::EmptyArray),
+        if !arr.is_empty() {
+            Ok(Self(arr))
+        } else {
+            Err(crate::Error::EmptyArray)
         }
     }
 

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -4,12 +4,13 @@ use core::fmt;
 #[cfg(any(feature = "sending", feature = "receiving"))]
 use crate::utils::hash::SharedSecretHash;
 use crate::Error;
-#[cfg(any(feature = "sending", feature = "receiving"))]
+#[cfg(any(feature = "sending", feature = "receiving", feature = "encode"))]
 use crate::Result;
 #[cfg(feature = "encode")]
 use bech32::{FromBase32, ToBase32};
 #[cfg(any(feature = "sending", feature = "receiving"))]
 use bitcoin_hashes::Hash;
+use secp256k1::constants::PUBLIC_KEY_SIZE;
 use secp256k1::PublicKey;
 #[cfg(any(feature = "sending", feature = "receiving"))]
 use secp256k1::{Scalar, Secp256k1, SecretKey};
@@ -19,6 +20,8 @@ use serde::ser::Serializer;
 use serde::Deserializer;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+pub const SILENT_PAYMENT_ADDRESS_BYTE_LEN: usize = 67;
 
 /// Struct representing an OutPoint type.
 ///
@@ -36,6 +39,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct OutPoint(pub(crate) [u8; 36]);
 
+#[cfg(any(feature = "sending", feature = "receiving"))]
 impl OutPoint {
     /// Parse outpoin from a [String] txid and [u32] vout.
     /// This may fail if the txid is not a valid 32 byte hex string.
@@ -145,18 +149,87 @@ impl TryFrom<u8> for SpVersion {
         match value {
             0 => Ok(Self::ZERO),
             _ => Err(Error::GenericError(
-                "Unknwon silent payment version".to_string(),
+                "Unknown silent payment version".to_string(),
             )),
         }
     }
 }
 
-/// A silent payment address struct that can be used to deserialize a silent payment address string.
+/// Core silent payment address data (version + pubkeys), without network.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub struct SilentPaymentAddressRaw {
+    version: SpVersion,
+    scan_key: PublicKey,
+    spend_key: PublicKey,
+}
+
+impl SilentPaymentAddressRaw {
+    pub fn new(version: SpVersion, scan_key: PublicKey, spend_key: PublicKey) -> Self {
+        Self {
+            version,
+            scan_key,
+            spend_key,
+        }
+    }
+
+    pub fn new_v0(scan_key: PublicKey, spend_key: PublicKey) -> Self {
+        Self::new(SpVersion::ZERO, scan_key, spend_key)
+    }
+
+    pub fn to_address_for_network(&self, network: Network) -> SilentPaymentAddress {
+        SilentPaymentAddress::from_raw(*self, network)
+    }
+
+    pub fn try_from_byte_array(bytes: &[u8; SILENT_PAYMENT_ADDRESS_BYTE_LEN]) -> Result<Self> {
+        let version: SpVersion = bytes[0].try_into()?;
+        let scan_key = PublicKey::from_slice(&bytes[1..34])?;
+        let spend_key = PublicKey::from_slice(&bytes[34..])?;
+        Ok(Self::new(version, scan_key, spend_key))
+    }
+
+    pub fn try_from_byte_array_v0(bytes: &[u8; PUBLIC_KEY_SIZE * 2]) -> Result<Self> {
+        let scan_key = PublicKey::from_slice(&bytes[..PUBLIC_KEY_SIZE])?;
+        let spend_key = PublicKey::from_slice(&bytes[PUBLIC_KEY_SIZE..])?;
+        Ok(Self::new(SpVersion::ZERO, scan_key, spend_key))
+    }
+
+    pub fn to_byte_array(&self) -> [u8; SILENT_PAYMENT_ADDRESS_BYTE_LEN] {
+        let mut bytes = [0u8; SILENT_PAYMENT_ADDRESS_BYTE_LEN];
+        bytes[0] = self.version.into();
+        bytes[1..34].copy_from_slice(&self.scan_key.serialize());
+        bytes[34..67].copy_from_slice(&self.spend_key.serialize());
+        bytes
+    }
+
+    pub fn version(&self) -> SpVersion {
+        self.version
+    }
+
+    pub fn scan_key(&self) -> PublicKey {
+        self.scan_key
+    }
+
+    pub fn spend_key(&self) -> PublicKey {
+        self.spend_key
+    }
+}
+
+impl From<SilentPaymentAddress> for SilentPaymentAddressRaw {
+    fn from(value: SilentPaymentAddress) -> Self {
+        value.raw
+    }
+}
+
+impl From<&SilentPaymentAddress> for SilentPaymentAddressRaw {
+    fn from(value: &SilentPaymentAddress) -> Self {
+        value.raw
+    }
+}
+
+/// A silent payment address with network, serializable as a bech32m string.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct SilentPaymentAddress {
-    version: SpVersion,
-    scan_pubkey: PublicKey,
-    m_pubkey: PublicKey,
+    raw: SilentPaymentAddressRaw,
     network: Network,
 }
 
@@ -184,11 +257,18 @@ impl<'de> Deserialize<'de> for SilentPaymentAddress {
 }
 
 impl SilentPaymentAddress {
+    pub fn from_raw(raw: SilentPaymentAddressRaw, network: Network) -> Self {
+        Self { raw, network }
+    }
+
     /// Construct a `SilentPaymentAddress` from its component parts.
     ///
-    /// This constructor is always available, even without the `encode` feature.
-    /// If you have your own bech32 parser, you can use it to extract the components
-    /// and then construct the address using this method.
+    /// This wraps a [`SilentPaymentAddressRaw`] with a [`Network`]. It is always
+    /// available, even without the `encode` feature. If you already have a
+    /// [`SilentPaymentAddressRaw`], prefer [`Self::from_raw`].
+    ///
+    /// If you have your own bech32 parser, parse the payload and network HRP,
+    /// then build the address with this method or with `from_raw`.
     ///
     /// # Bech32 Format (for external parsers)
     ///
@@ -197,57 +277,63 @@ impl SilentPaymentAddress {
     ///   - Mainnet: `"sp"`
     ///   - Testnet/Signet: `"tsp"`
     ///   - Regtest: `"sprt"`
-    /// - **Data**: version (1 byte) + scan_pubkey (33 bytes) + spend_pubkey (33 bytes)
+    /// - **Data**: version (1 byte) + scan key (33 bytes) + spend key (33 bytes)
     ///
     /// # Example
     ///
     /// ```ignore
     /// use secp256k1::PublicKey;
-    /// use silentpayments::{SilentPaymentAddress, Network};
+    /// use silentpayments::{Network, SilentPaymentAddress, SpVersion};
     ///
     /// // After parsing bech32 yourself and extracting the pubkeys:
-    /// let scan_pubkey = PublicKey::from_slice(&scan_bytes)?;
-    /// let spend_pubkey = PublicKey::from_slice(&spend_bytes)?;
+    /// let scan_key = PublicKey::from_slice(&scan_bytes)?;
+    /// let spend_key = PublicKey::from_slice(&spend_bytes)?;
     ///
     /// let address = SilentPaymentAddress::new(
-    ///     scan_pubkey,
-    ///     spend_pubkey,
+    ///     scan_key,
+    ///     spend_key,
     ///     Network::Mainnet,
-    ///     0  // version
-    /// )?;
+    ///     SpVersion::ZERO,
+    /// );
+    ///
+    /// // To use the sending API, strip the network:
+    /// let raw: silentpayments::SilentPaymentAddressRaw = address.into();
     /// ```
     pub fn new(
-        scan_pubkey: PublicKey,
-        m_pubkey: PublicKey,
+        scan_key: PublicKey,
+        spend_key: PublicKey,
         network: Network,
         version: SpVersion,
     ) -> Self {
-        SilentPaymentAddress {
-            scan_pubkey,
-            m_pubkey,
+        Self::from_raw(
+            SilentPaymentAddressRaw::new(version, scan_key, spend_key),
             network,
-            version,
-        }
+        )
     }
 
-    /// Get the scan public key.
-    pub fn get_scan_key(&self) -> PublicKey {
-        self.scan_pubkey
+    /// Calls new() with version set at SpVersion::ZERO
+    pub fn new_v0(scan_key: PublicKey, spend_key: PublicKey, network: Network) -> Self {
+        Self::new(scan_key, spend_key, network, SpVersion::ZERO)
     }
 
-    /// Get the spend public key.
-    pub fn get_spend_key(&self) -> PublicKey {
-        self.m_pubkey
+    pub fn scan_key(&self) -> PublicKey {
+        self.raw.scan_key()
     }
 
-    /// Get the network.
-    pub fn get_network(&self) -> Network {
+    pub fn spend_key(&self) -> PublicKey {
+        self.raw.spend_key()
+    }
+
+    pub fn network(&self) -> Network {
         self.network
     }
 
-    /// Get the version byte.
-    pub fn get_version(&self) -> u8 {
-        self.version.into()
+    pub fn version(&self) -> SpVersion {
+        self.raw.version()
+    }
+
+    pub fn to_byte_array(&self) -> [u8; SILENT_PAYMENT_ADDRESS_BYTE_LEN] {
+        self.raw.to_byte_array()
     }
 }
 
@@ -285,14 +371,12 @@ impl TryFrom<&str> for SilentPaymentAddress {
 
         let data = Vec::<u8>::from_base32(&data[1..])?;
 
-        let scan_pubkey = PublicKey::from_slice(&data[..33])?;
-        let m_pubkey = PublicKey::from_slice(&data[33..])?;
+        let scan_key = PublicKey::from_slice(&data[..33])?;
+        let spend_key = PublicKey::from_slice(&data[33..])?;
 
-        Ok(SilentPaymentAddress::new(
-            scan_pubkey,
-            m_pubkey,
+        Ok(SilentPaymentAddress::from_raw(
+            SilentPaymentAddressRaw::new(version, scan_key, spend_key),
             network,
-            version,
         ))
     }
 }
@@ -315,16 +399,16 @@ impl From<SilentPaymentAddress> for String {
             Network::Mainnet => "sp",
         };
 
-        let version = bech32::u5::try_from_u8(val.version.into()).unwrap();
+        let version = bech32::u5::try_from_u8(val.version().into()).expect("Always 0");
 
-        let B_scan_bytes = val.scan_pubkey.serialize();
-        let B_m_bytes = val.m_pubkey.serialize();
+        let B_scan_bytes = val.scan_key().serialize();
+        let B_m_bytes = val.spend_key().serialize();
 
         let mut data = [B_scan_bytes, B_m_bytes].concat().to_base32();
 
         data.insert(0, version);
 
-        bech32::encode(hrp, data, bech32::Variant::Bech32m).unwrap()
+        bech32::encode(hrp, data, bech32::Variant::Bech32m).expect("We know our hrps")
     }
 }
 

--- a/silentpayments/tests/common/utils.rs
+++ b/silentpayments/tests/common/utils.rs
@@ -3,7 +3,7 @@ use std::{fs::File, io::Read, str::FromStr};
 use bitcoin_hashes::Hash;
 use secp256k1::{Message, Scalar, SecretKey, XOnlyPublicKey};
 use serde_json::from_str;
-use silentpayments::SilentPaymentAddress;
+use silentpayments::{SilentPaymentAddress, SilentPaymentAddressRaw};
 
 use super::structs::{OutputWithSignature, TestData};
 
@@ -63,10 +63,13 @@ pub fn decode_outputs_to_check(outputs: &[String]) -> Vec<XOnlyPublicKey> {
         .collect()
 }
 
-pub fn decode_recipients(recipients: &[String]) -> Vec<SilentPaymentAddress> {
+pub fn decode_recipients(recipients: &[String]) -> Vec<SilentPaymentAddressRaw> {
     recipients
         .iter()
-        .map(|sp_addr_str| sp_addr_str.as_str().try_into().unwrap())
+        .map(|sp_addr_str| {
+            let address: SilentPaymentAddress = sp_addr_str.as_str().try_into().unwrap();
+            address.into()
+        })
         .collect()
 }
 

--- a/spdk-wallet/src/client/client.rs
+++ b/spdk-wallet/src/client/client.rs
@@ -115,8 +115,8 @@ impl SpClient {
 
     pub fn get_client_fingerprint(&self) -> Result<[u8; 8]> {
         let sp_address: SilentPaymentAddress = self.get_receiving_address();
-        let scan_pk = sp_address.get_scan_key();
-        let spend_pk = sp_address.get_spend_key();
+        let scan_pk = sp_address.scan_key();
+        let spend_pk = sp_address.spend_key();
 
         // take a fingerprint of the wallet by hashing its keys
         let mut engine = sha256::HashEngine::default();

--- a/spdk-wallet/src/client/spend.rs
+++ b/spdk-wallet/src/client/spend.rs
@@ -16,9 +16,9 @@ use bitcoin::transaction::Version;
 use bitcoin::{
     Amount, Network, OutPoint, ScriptBuf, Sequence, TapLeafHash, Transaction, TxIn, TxOut, Witness,
 };
-use silentpayments::utils as sp_utils;
+use silentpayments::Network as SpNetwork;
 use silentpayments::utils::sending::PartialSecret;
-use silentpayments::{Network as SpNetwork, SilentPaymentAddress};
+use silentpayments::{SilentPaymentAddressRaw, utils as sp_utils};
 
 use spdk_core::constants::{DATA_CARRIER_SIZE, NUMS};
 use spdk_core::updater::DiscoveredOutput;
@@ -64,7 +64,7 @@ impl SpClient {
                     })
                 }
                 RecipientAddress::SpAddress(sp_address) => {
-                    if sp_address.get_network() != address_sp_network {
+                    if sp_address.network() != address_sp_network {
                         return Err(Error::msg(format!(
                             "Wrong network for address {}",
                             sp_address
@@ -181,7 +181,7 @@ impl SpClient {
                 script_pubkey: address.clone().require_network(network)?.script_pubkey(),
             }),
             RecipientAddress::SpAddress(sp_address) => {
-                if sp_address.get_network() != address_sp_network {
+                if sp_address.network() != address_sp_network {
                     return Err(Error::msg(format!(
                         "Wrong network for address {}",
                         sp_address
@@ -266,11 +266,13 @@ impl SpClient {
             })
             .collect();
 
-        let sp_addresses: Vec<SilentPaymentAddress> = unsigned_transaction
+        let sp_addresses: Vec<SilentPaymentAddressRaw> = unsigned_transaction
             .recipients
             .iter()
             .filter_map(|r| match &r.address {
-                RecipientAddress::SpAddress(sp_address) => Some(sp_address.to_owned()),
+                RecipientAddress::SpAddress(sp_address) => {
+                    Some(SilentPaymentAddressRaw::from(sp_address))
+                }
                 _ => None,
             })
             .collect();
@@ -287,7 +289,7 @@ impl SpClient {
                 RecipientAddress::SpAddress(s) => {
                     // We now need to fill the sp outputs with actual spk
                     let pubkeys = sp_address2xonlypubkeys
-                        .get(s)
+                        .get(&SilentPaymentAddressRaw::from(s))
                         .ok_or(Error::msg("Unknown sp address"))?;
 
                     // we currently only allow having 1 output per silent payment address


### PR DESCRIPTION
Acknowledging that we often can't use `SilentPaymentAddress` type because we don't have the network, or we can have it but it's irrelevant, especially in psbt context, we need a type that only contains version, scan key and spend key. We also need to do back and forth with a bytes array representation of those data. 

Instead of stripping the existing type of `network`, which would break all existing code, we propose to define another, simpler type, `SilentPaymentAddressRaw`, that is basically a very thin wrapper around a `[u8; 67]`, but also offers type guarantees and more readability.

First place we would use that type is `generate_recipient_pubkeys`