### PR TITLE
feat: define scan/spend keys derivation path as constants

### DIFF
--- a/silentpayments/examples/create_wallet.rs
+++ b/silentpayments/examples/create_wallet.rs
@@ -7,6 +7,7 @@ use bitcoin::secp256k1::Secp256k1;
 
 // Import types from the silentpayments library
 use silentpayments::receiving::{Label, Receiver};
+use silentpayments::utils::{TEST_SCAN_PATH, TEST_SPEND_PATH};
 use silentpayments::{Network, SpVersion};
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -24,8 +25,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let master_key = Xpriv::new_master(bitcoin::Network::Signet, &m.to_seed(passphrase))?;
 
     // Define the scan and spend paths for the wallet
-    let scan_path = DerivationPath::from_str("m/352h/1h/0h/1h/0").unwrap();
-    let spend_path = DerivationPath::from_str("m/352h/1h/0h/0h/0").unwrap();
+    let scan_path = DerivationPath::from_str(TEST_SCAN_PATH).unwrap();
+    let spend_path = DerivationPath::from_str(TEST_SPEND_PATH).unwrap();
 
     // Get the private keys for both scan and spend paths
     let scan_privkey = master_key.derive_priv(&secp, &scan_path)?.private_key;

--- a/silentpayments/examples/find_output.rs
+++ b/silentpayments/examples/find_output.rs
@@ -8,7 +8,7 @@ use bitcoin::secp256k1::{PublicKey, Secp256k1, XOnlyPublicKey};
 use bitcoin::{Network, PrivateKey, ScriptBuf, Transaction};
 use bitcoin_hashes::hex::FromHex;
 
-use silentpayments::utils::OutPoint;
+use silentpayments::utils::{OutPoint, TEST_SCAN_PATH, TEST_SPEND_PATH};
 use silentpayments::SpVersion;
 // Import types from the silentpayments library
 use silentpayments::receiving::{Label, Receiver};
@@ -38,8 +38,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let master_key = Xpriv::new_master(bitcoin::Network::Signet, &m.to_seed(""))?;
 
     // Define the scan and spend paths for the wallet
-    let scan_path = DerivationPath::from_str("m/352h/1h/0h/1h/0").unwrap();
-    let spend_path = DerivationPath::from_str("m/352h/1h/0h/0h/0").unwrap();
+    let scan_path = DerivationPath::from_str(TEST_SCAN_PATH).unwrap();
+    let spend_path = DerivationPath::from_str(TEST_SPEND_PATH).unwrap();
 
     // Create a new instance of Secp256k1 for cryptographic operations
     let secp = Secp256k1::signing_only();

--- a/silentpayments/src/utils.rs
+++ b/silentpayments/src/utils.rs
@@ -33,3 +33,9 @@ const OP_CHECKSIG: u8 = 0xAC;
 
 // Only compressed pubkeys are supported for silent payments
 const COMPRESSED_PUBKEY_SIZE: usize = 33;
+
+// Derivation paths according to BIP
+pub const MAIN_SCAN_PATH: &str = "m/352h/0h/0h/1h/0";
+pub const MAIN_SPEND_PATH: &str = "m/352h/0h/0h/0h/0";
+pub const TEST_SCAN_PATH: &str = "m/352h/1h/0h/1h/0";
+pub const TEST_SPEND_PATH: &str = "m/352h/1h/0h/0h/0";


### PR DESCRIPTION
Very straightforward, defines the derivation paths for scan and spend key as public constants instead of hardcoding it.