### PR TITLE
Refactor/new api wallet migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ reqwest = { version = "0.12.4", features = [
   "rustls-tls",
   "gzip",
 ], default-features = false }
+rust-dleq = { git = "https://github.com/macgyver13/rust-dleq.git", branch = "master", default-features = false }
 secp256k1 = { version = "0.29.0" }
 
 [workspace.package]

--- a/silentpayments/Cargo.toml
+++ b/silentpayments/Cargo.toml
@@ -16,11 +16,13 @@ name = "silentpayments"
 crate-type = ["lib"]
 
 [features]
-default = ["encode", "sending", "receiving"]
+default = ["encode", "sending", "receiving", "dleq-native"]
 encode = ["dep:bech32"]
 serde = ["dep:serde"]
 sending = ["dep:bitcoin_hashes", "dep:hex", "encode"]
 receiving = ["dep:bitcoin_hashes", "dep:hex", "serde", "encode"]
+dleq-standalone = ["sending", "dep:rust-dleq", "rust-dleq/standalone"]
+dleq-native = ["sending", "dep:rust-dleq", "rust-dleq/native"]
 
 [dependencies]
 secp256k1.workspace = true
@@ -28,6 +30,7 @@ hex = { workspace = true, optional = true }
 bech32 = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 bitcoin_hashes = { workspace = true, optional = true }
+rust-dleq = { workspace = true, optional = true }
 
 [dev-dependencies]
 rust-bip39 = { version = "1.0.0", features = ["rand"] }
@@ -44,4 +47,4 @@ required-features = ["receiving"]
 
 [[test]]
 name = "vector_tests"
-required-features = ["receiving", "sending"]
+required-features = ["receiving", "sending", "dleq-native"]

--- a/silentpayments/README.md
+++ b/silentpayments/README.md
@@ -57,13 +57,7 @@ silentpayments = { version = "0.4", default-features = false, features = ["recei
 
 ## Sending
 
-For sending to a silent payment address, you can call the `sender::generate_recipient_pubkeys` function.
-This function takes a list of silent payment recipients, as well as a `partial_secret`.
-
-The `partial_secret` represents the sum of all input private keys multiplied with the input hash.
-To compute the `partial_secret`, the `utils::sending::compute_partial_secret` function can be used,
-although this requires exposing secret data to this library.
-Other methods for calculating the `partial_secret` will be added later.
+For sending to silent payment addresses, build a [`TransactionSharedSecret`](https://docs.rs/silentpayments/latest/silentpayments/struct.TransactionSharedSecret.html) per recipient scan key using [`GlobalSenderEcdhShare`](https://docs.rs/silentpayments/latest/silentpayments/utils/sending/struct.GlobalSenderEcdhShare.html) or [`PartialSenderEcdhShare`](https://docs.rs/silentpayments/latest/silentpayments/utils/sending/struct.PartialSenderEcdhShare.html), then call `sending::generate_recipient_pubkeys`.
 
 ## Recipient
 

--- a/silentpayments/examples/find_output.rs
+++ b/silentpayments/examples/find_output.rs
@@ -1,38 +1,28 @@
 use std::{env, error::Error, str::FromStr};
 
-// Import necessary libraries and modules
 use bip39::Mnemonic;
 use bitcoin::bip32::{DerivationPath, Xpriv};
 use bitcoin::consensus::deserialize;
-use bitcoin::secp256k1::{PublicKey, Secp256k1, XOnlyPublicKey};
+use bitcoin::secp256k1::Secp256k1 as BtcSecp256k1;
 use bitcoin::{Network, PrivateKey, ScriptBuf, Transaction};
 use bitcoin_hashes::hex::FromHex;
 
-use silentpayments::utils::{OutPoint, TEST_SCAN_PATH, TEST_SPEND_PATH};
-use silentpayments::SpVersion;
+use silentpayments::utils::{TEST_SCAN_PATH, TEST_SPEND_PATH};
 // Import types from the silentpayments library
 use silentpayments::receiving::{Label, Receiver};
-use silentpayments::utils::receiving::{
-    calculate_ecdh_shared_secret, calculate_tweak_data, get_pubkey_from_input,
-};
+use silentpayments::secp256k1::{Secp256k1, SecretKey, XOnlyPublicKey};
+use silentpayments::utils::receiving::{get_pubkey_from_input, PublicTweakData};
+use silentpayments::utils::OutPoint;
+use silentpayments::{Network as SpNetwork, SpVersion, TransactionInputs, TransactionSharedSecret};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // Get the command-line arguments
     let args: Vec<String> = env::args().collect();
 
-    // Parse the mnemonic phrase from the first command-line argument
     let m = Mnemonic::from_str(args.get(1).unwrap())?;
-
-    // Get the transaction hex string from the second command-line argument
     let tx_hex = args.get(2).unwrap();
-
-    // Parse the scriptpubkeys from the third command-line argument, split by whitespace and store them in a vector
     let spks: Vec<&str> = args.get(3).unwrap().split_whitespace().collect();
 
-    // Deserialize the transaction hex string into a Transaction object
     let tx: Transaction = deserialize(Vec::from_hex(tx_hex)?.as_slice())?;
-
-    // Assert that the number of inputs in the transaction matches the number of scriptpubkeys provided
     assert!(tx.input.len() == spks.len());
 
     let master_key = Xpriv::new_master(bitcoin::Network::Signet, &m.to_seed(""))?;
@@ -41,58 +31,42 @@ fn main() -> Result<(), Box<dyn Error>> {
     let scan_path = DerivationPath::from_str(TEST_SCAN_PATH).unwrap();
     let spend_path = DerivationPath::from_str(TEST_SPEND_PATH).unwrap();
 
-    // Create a new instance of Secp256k1 for cryptographic operations
-    let secp = Secp256k1::signing_only();
+    let btc_secp = BtcSecp256k1::signing_only();
+    let secp = Secp256k1::new();
 
-    // Get the private keys for both scan and spend paths
-    let scan_privkey = master_key.derive_priv(&secp, &scan_path)?.private_key;
-    let spend_privkey = master_key.derive_priv(&secp, &spend_path)?.private_key;
+    let scan_privkey = master_key.derive_priv(&btc_secp, &scan_path)?.private_key;
+    let spend_privkey = master_key.derive_priv(&btc_secp, &spend_path)?.private_key;
+    let scan_sk = SecretKey::from_slice(&scan_privkey.secret_bytes())?;
+    let spend_sk = SecretKey::from_slice(&spend_privkey.secret_bytes())?;
 
-    // Create a change label for the wallet
-    let change_label = Label::new(scan_privkey, 0);
+    let change_label = Label::new(scan_sk, 0);
 
-    // Create a new Receiver object with the private and public keys, along with the change label
     let receiver = Receiver::new(
         SpVersion::ZERO,
-        scan_privkey.public_key(&secp),
-        spend_privkey.public_key(&secp),
+        scan_sk.public_key(&secp),
+        spend_sk.public_key(&secp),
         change_label,
-        silentpayments::Network::Testnet,
+        SpNetwork::Testnet,
     )?;
 
-    // Extract outpoints (previous transaction outputs) from the transaction inputs and store them in a vector
-    let outpoints: Vec<OutPoint> = tx
-        .input
-        .iter()
-        .map(|i| {
-            let prevout = i.previous_output;
-            OutPoint::from_txid_and_vout(prevout.txid.to_string(), prevout.vout).unwrap()
-        })
-        .collect();
-
-    // Iterate through each input of the transaction and assert if it contains an eligible pubkey
-    let mut input_pubkeys: Vec<PublicKey> = vec![];
+    let mut inputs = TransactionInputs::new();
     for (i, input) in tx.input.iter().enumerate() {
+        let prevout = &input.previous_output;
+        let outpoint =
+            OutPoint::from_txid_and_vout(prevout.txid.to_string(), prevout.vout).unwrap();
         let spk = ScriptBuf::from_hex(spks.get(i).unwrap())?;
-        if let Some(pubkey) = get_pubkey_from_input(
+        let pubkey = get_pubkey_from_input(
             input.script_sig.as_bytes(),
             &input.witness.to_vec(),
             spk.as_bytes(),
-        )? {
-            input_pubkeys.push(pubkey);
-        }
+        )?;
+        inputs.push(outpoint, spk.to_bytes(), pubkey);
     }
 
-    // Get the reference to a vector of public keys for further calculations
-    let pubkeys_ref: Vec<&PublicKey> = input_pubkeys.iter().collect();
+    let tweak_data = PublicTweakData::new(&secp, &inputs)?;
+    let ecdh_shared_secret =
+        TransactionSharedSecret::new_from_public_tweak_data(&secp, &tweak_data, &scan_sk)?;
 
-    // Calculate the tweak data based on the public keys and outpoints
-    let tweak_data = calculate_tweak_data(&pubkeys_ref, &outpoints)?;
-
-    // Calculate the ECDH shared secret between the scan private key and the tweak data
-    let ecdh_shared_secret = calculate_ecdh_shared_secret(&tweak_data, &scan_privkey);
-
-    // Filter the transaction outputs that have a valid P2TR scriptpubkey
     let pubkeys_to_check: Vec<_> = tx
         .output
         .iter()
@@ -103,16 +77,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         })
         .collect();
 
-    // Scan the transaction for eligible outputs and store them in a vector with their corresponding labels and key maps
     let my_outputs = receiver.scan_transaction(&ecdh_shared_secret, &pubkeys_to_check)?;
 
     println!("Found {} output(s)", my_outputs.len());
 
-    // Iterate through each found output and print the private key required to spend it along with its descriptor for importing into Bitcoin Core
     for (label, key_map) in my_outputs {
         println!("Found {} output(s) with label {:?}", key_map.len(), label);
         for (xonly, sk) in key_map {
-            let spending_key = spend_privkey.add_tweak(&sk).unwrap();
+            let spending_key = spend_sk.add_tweak(&sk)?;
             let wif = PrivateKey::from_slice(&spending_key.secret_bytes(), Network::Signet)
                 .unwrap()
                 .to_wif();

--- a/silentpayments/src/error.rs
+++ b/silentpayments/src/error.rs
@@ -64,3 +64,13 @@ impl From<std::io::Error> for Error {
         Error::IOError(e)
     }
 }
+
+#[cfg(all(
+    feature = "sending",
+    any(feature = "dleq-standalone", feature = "dleq-native")
+))]
+impl From<rust_dleq::DleqError> for Error {
+    fn from(e: rust_dleq::DleqError) -> Self {
+        Error::GenericError(e.to_string())
+    }
+}

--- a/silentpayments/src/lib.rs
+++ b/silentpayments/src/lib.rs
@@ -54,6 +54,8 @@ pub use crate::error::Error;
 pub use utils::common::Network;
 #[cfg(any(feature = "sending", feature = "receiving"))]
 pub use utils::common::SharedSecret;
+#[cfg(any(feature = "sending", feature = "receiving"))]
+pub use utils::common::TransactionInputs;
 pub use utils::common::SilentPaymentAddress;
 pub use utils::common::SpVersion;
 

--- a/silentpayments/src/lib.rs
+++ b/silentpayments/src/lib.rs
@@ -8,7 +8,8 @@
 //! - **default**: Enables `encode`, `sending`, and `receiving` features
 //! - **encode**: Enables string encoding/decoding for `SilentPaymentAddress` (requires `bech32`)
 //! - **serde**: Enables serde serialization/deserialization for types
-//! - **sending**: Enables sending functionality (requires `bitcoin_hashes`, `hex`, and `encode`)
+//! - **sending**: Enables sending functionality (requires `bitcoin_hashes`, `hex`, `rust-dleq`, and `encode`).
+//!   Also enable exactly one of `dleq-standalone` (pure Rust, default) or `dleq-native` (libsecp256k1 C).
 //! - **receiving**: Enables receiving functionality (requires `bitcoin_hashes`, `hex`, `serde`, and `encode`)
 //!
 //! ### Minimal Usage
@@ -38,11 +39,23 @@
 //! Alternatively, have a look at [Sp client](https://github.com/cygnet3/sp-client/tree/master),
 //! which is a WIP wallet client for building silent payment wallets.
 #![allow(dead_code, non_snake_case)]
+
+#[cfg(all(
+    feature = "sending",
+    not(any(feature = "dleq-standalone", feature = "dleq-native"))
+))]
+compile_error!(
+    "The `sending` feature requires either `dleq-standalone` or `dleq-native` to select a DLEQ backend."
+);
+
 mod error;
 
 #[cfg(feature = "receiving")]
 pub mod receiving;
-#[cfg(feature = "sending")]
+#[cfg(all(
+    feature = "sending",
+    any(feature = "dleq-standalone", feature = "dleq-native")
+))]
 pub mod sending;
 pub mod utils;
 
@@ -51,12 +64,15 @@ pub use bitcoin_hashes;
 pub use secp256k1;
 
 pub use crate::error::Error;
+#[cfg(all(
+    feature = "sending",
+    any(feature = "dleq-standalone", feature = "dleq-native")
+))]
+pub use rust_dleq::DleqProof;
 pub use utils::common::Network;
 pub use utils::common::SilentPaymentAddress;
 pub use utils::common::SpVersion;
 #[cfg(any(feature = "sending", feature = "receiving"))]
-pub use utils::common::TransactionInputs;
-#[cfg(any(feature = "sending", feature = "receiving"))]
-pub use utils::common::TransactionSharedSecret;
+pub use utils::common::{NonEmptyArray, TransactionInputs, TransactionSharedSecret};
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/silentpayments/src/lib.rs
+++ b/silentpayments/src/lib.rs
@@ -9,7 +9,7 @@
 //! - **encode**: Enables string encoding/decoding for `SilentPaymentAddress` (requires `bech32`)
 //! - **serde**: Enables serde serialization/deserialization for types
 //! - **sending**: Enables sending functionality (requires `bitcoin_hashes`, `hex`, and `encode`)
-//! - **receiving**: Enables receiving functionality (requires `bitcoin_hashes`, `hex`, `bimap`, `serde`, and `encode`)
+//! - **receiving**: Enables receiving functionality (requires `bitcoin_hashes`, `hex`, `serde`, and `encode`)
 //!
 //! ### Minimal Usage
 //!
@@ -52,11 +52,11 @@ pub use secp256k1;
 
 pub use crate::error::Error;
 pub use utils::common::Network;
-#[cfg(any(feature = "sending", feature = "receiving"))]
-pub use utils::common::SharedSecret;
-#[cfg(any(feature = "sending", feature = "receiving"))]
-pub use utils::common::TransactionInputs;
 pub use utils::common::SilentPaymentAddress;
 pub use utils::common::SpVersion;
+#[cfg(any(feature = "sending", feature = "receiving"))]
+pub use utils::common::TransactionInputs;
+#[cfg(any(feature = "sending", feature = "receiving"))]
+pub use utils::common::TransactionSharedSecret;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/silentpayments/src/lib.rs
+++ b/silentpayments/src/lib.rs
@@ -55,6 +55,7 @@ pub use utils::common::Network;
 #[cfg(any(feature = "sending", feature = "receiving"))]
 pub use utils::common::SharedSecret;
 pub use utils::common::SilentPaymentAddress;
+pub use utils::common::SilentPaymentAddressRaw;
 pub use utils::common::SpVersion;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/silentpayments/src/receiving.rs
+++ b/silentpayments/src/receiving.rs
@@ -6,10 +6,13 @@
 //!
 //! After creating a [`Receiver`] object, you can call [`scan_transaction`](Receiver::scan_transaction),
 //! to scan a specific transaction for outputs belonging to this receiver.
-//! For this, you need to have calculated the `ecdh_shared_secret` beforehand.
-//! To do so, you can use [`calculate_ecdh_shared_secret`](`crate::utils::receiving::calculate_ecdh_shared_secret`) from the `utils` module.
 //!
-//! For a concrete example, have a look at the [test vectors](https://github.com/cygnet3/rust-silentpayments/blob/master/tests/vector_tests.rs).
+//! This requires a [`TransactionSharedSecret`] for the transaction. Compute it from
+//! [`PublicTweakData`](crate::utils::receiving::PublicTweakData) and the scan private key via
+//! [`TransactionSharedSecret::new_from_public_tweak_data`].
+//!
+//! For a concrete example, see the [test vectors](https://github.com/cygnet3/spdk/blob/master/silentpayments/tests/vector_tests.rs)
+//! or the `find_output` example.
 use std::{
     collections::{HashMap, HashSet},
     fmt,
@@ -17,8 +20,8 @@ use std::{
 
 use crate::{
     utils::{
-        common::{calculate_P_n, calculate_t_n, SharedSecret},
-        hash::LabelHash,
+        common::{calculate_P_n, calculate_t_n, TransactionSharedSecret},
+        hash::calculate_label_hash,
     },
     Error, Network, Result, SilentPaymentAddress, SpVersion,
 };
@@ -38,7 +41,7 @@ pub struct Label {
 impl Label {
     pub fn new(b_scan: SecretKey, m: u32) -> Label {
         Label {
-            s: LabelHash::from_b_scan_and_m(b_scan, m).to_scalar(),
+            s: calculate_label_hash(b_scan, m),
         }
     }
 
@@ -377,7 +380,7 @@ impl Receiver {
     /// * An error occurs during elliptic curve computation. This may happen if a sender is being malicious.
     pub fn scan_transaction(
         &self,
-        ecdh_shared_secret: &SharedSecret,
+        ecdh_shared_secret: &TransactionSharedSecret,
         pubkeys_to_check: &[XOnlyPublicKey],
     ) -> Result<HashMap<Option<Label>, HashMap<XOnlyPublicKey, Scalar>>> {
         let secp = secp256k1::Secp256k1::new();
@@ -437,7 +440,7 @@ impl Receiver {
     /// * An error occurs during elliptic curve computation. This may happen if a sender is being malicious.
     pub fn get_spks_from_shared_secret(
         &self,
-        ecdh_shared_secret: &SharedSecret,
+        ecdh_shared_secret: &TransactionSharedSecret,
     ) -> Result<HashMap<Option<Label>, [u8; 34]>> {
         let t_0: SecretKey = calculate_t_n(ecdh_shared_secret, 0)?;
         let P_0: PublicKey = calculate_P_n(&self.spend_pubkey, t_0.into())?;

--- a/silentpayments/src/sending.rs
+++ b/silentpayments/src/sending.rs
@@ -12,7 +12,7 @@ use secp256k1::{PublicKey, Secp256k1, XOnlyPublicKey};
 use std::collections::HashMap;
 
 use crate::utils::common::calculate_t_n;
-use crate::utils::common::SharedSecret;
+use crate::utils::common::TransactionSharedSecret;
 use crate::utils::sending::calculate_ecdh_shared_secret;
 use crate::utils::sending::PartialSecret;
 use crate::Result;
@@ -46,8 +46,10 @@ pub fn generate_recipient_pubkeys(
 ) -> Result<HashMap<SilentPaymentAddress, Vec<XOnlyPublicKey>>> {
     let secp = Secp256k1::new();
 
-    let mut silent_payment_groups: HashMap<PublicKey, (SharedSecret, Vec<SilentPaymentAddress>)> =
-        HashMap::new();
+    let mut silent_payment_groups: HashMap<
+        PublicKey,
+        (TransactionSharedSecret, Vec<SilentPaymentAddress>),
+    > = HashMap::new();
     for address in recipients {
         let B_scan = address.get_scan_key();
 

--- a/silentpayments/src/sending.rs
+++ b/silentpayments/src/sending.rs
@@ -1,12 +1,12 @@
 //! The sending component of silent payments.
 //!
-//! The [`generate_recipient_pubkeys`] function can be used to create outputs for a list of silent payment recipients.
+//! The [`generate_recipient_pubkeys`] function creates taproot output keys for silent payment recipients.
 //!
-//! Using [`generate_recipient_pubkeys`] will require calculating a
-//! `partial_secret` beforehand.
-//! To do this, you can use [`calculate_partial_secret`](crate::utils::sending::calculate_partial_secret) from the `utils` module.
-//! See the [tests on github](https://github.com/cygnet3/rust-silentpayments/blob/master/tests/vector_tests.rs)
-//! for a concrete example.
+//! Callers must supply a [`TransactionSharedSecret`] per unique recipient scan key.
+//! On the sender side, build secrets from a [`GlobalSenderEcdhShare`](crate::utils::sending::GlobalSenderEcdhShare)
+//! or from combined [`PartialSenderEcdhShare`](crate::utils::sending::PartialSenderEcdhShare)s.
+//! See [the test vectors](https://github.com/cygnet3/spdk/blob/master/silentpayments/tests/vector_tests.rs)
+//! for a full example.
 
 use secp256k1::{PublicKey, Secp256k1, XOnlyPublicKey};
 use std::collections::HashMap;
@@ -14,67 +14,69 @@ use std::collections::HashMap;
 use crate::utils::common::calculate_t_n;
 use crate::utils::common::SilentPaymentAddressRaw;
 use crate::utils::common::TransactionSharedSecret;
-use crate::utils::sending::calculate_ecdh_shared_secret;
-use crate::utils::sending::PartialSecret;
-use crate::Result;
+use crate::{Error, Result};
 
-/// Create outputs for a given set of silent payment recipients and their corresponding shared secrets.
+/// Create taproot output keys for a set of silent payment recipients.
 ///
-/// When creating the outputs for a transaction, this function should be used to generate the output keys.
-///
-/// This function should only be used once per transaction! If used multiple times, address reuse may occur.
+/// Recipients are grouped by scan key. Within each group the BIP352 output-index counter `n`
+/// increments in the order the addresses appear in `recipients`, so callers must pass addresses
+/// in their intended output order. Calling this function more than once for the same transaction
+/// with the same `shared_secrets` will restart every `n` counter at 0, producing duplicate output
+/// keys and breaking recipient privacy — call it exactly once per transaction.
 ///
 /// # Arguments
 ///
-/// * `recipients` - A [Vec] of silent payment addresses to be paid.
-/// * `partial_secret` - [PartialSecret] that represents the sum of the private keys of eligible inputs of the transaction multiplied by the input hash.
+/// * `recipients` - Silent payment addresses to pay, in output order. Multiple entries may share
+///   the same scan key; `n` is assigned within that scan-key group in the order given.
+/// * `shared_secrets` - One [`TransactionSharedSecret`] per unique scan key, keyed by that scan
+///   `PublicKey`. Each entry's internally stored scan key must equal its map key.
 ///
 /// # Returns
 ///
-/// If successful, the function returns a [Result] wrapping a [HashMap] of silent payment addresses to a [Vec].
-/// The [Vec] contains all the outputs that are associated with the silent payment address.
-///
-/// # Errors
-///
-/// This function will return an error if:
-///
-/// * Edge cases are hit during elliptic curve computation (extremely unlikely).
-pub fn generate_recipient_pubkeys(
-    recipients: Vec<SilentPaymentAddressRaw>,
-    partial_secret: PartialSecret,
+/// A [`HashMap`] whose keys are the original addresses from `recipients` and whose values are the
+/// corresponding taproot [`XOnlyPublicKey`] outputs.
+pub fn generate_recipient_pubkeys<C: secp256k1::Signing>(
+    secp: &Secp256k1<C>,
+    recipients: &[SilentPaymentAddressRaw],
+    shared_secrets: &HashMap<PublicKey, TransactionSharedSecret>,
 ) -> Result<HashMap<SilentPaymentAddressRaw, Vec<XOnlyPublicKey>>> {
-    let secp = Secp256k1::new();
-
     let mut silent_payment_groups: HashMap<
         PublicKey,
         (TransactionSharedSecret, Vec<SilentPaymentAddressRaw>),
     > = HashMap::new();
+
     for address in recipients {
         let recipient_scan_key = address.get_scan_pubkey();
 
         if let Some((_, payments)) = silent_payment_groups.get_mut(&recipient_scan_key) {
-            payments.push(address);
+            payments.push(*address);
         } else {
-            let ecdh_shared_secret =
-                calculate_ecdh_shared_secret(&recipient_scan_key, &partial_secret);
-
-            silent_payment_groups.insert(recipient_scan_key, (ecdh_shared_secret, vec![address]));
+            let shared_secret = shared_secrets.get(&recipient_scan_key).ok_or_else(|| {
+                Error::GenericError(format!(
+                    "Missing shared secret for scan key {recipient_scan_key}"
+                ))
+            })?;
+            if shared_secret.as_recipient_scan_key() != &recipient_scan_key {
+                return Err(Error::GenericError(format!(
+                    "Shared secret stored under scan key {recipient_scan_key} has mismatched \
+                     internal scan key {}",
+                    shared_secret.as_recipient_scan_key()
+                )));
+            }
+            silent_payment_groups.insert(recipient_scan_key, (*shared_secret, vec![*address]));
         }
     }
 
     let mut result: HashMap<SilentPaymentAddressRaw, Vec<XOnlyPublicKey>> = HashMap::new();
-    for group in silent_payment_groups.into_values() {
-        let (ecdh_shared_secret, recipients) = group;
-
-        for (n, addr) in recipients.into_iter().enumerate() {
+    for (ecdh_shared_secret, addresses) in silent_payment_groups.into_values() {
+        for (n, addr) in addresses.into_iter().enumerate() {
             let t_n = calculate_t_n(&ecdh_shared_secret, n as u32)?;
 
-            let res = t_n.public_key(&secp);
+            let res = t_n.public_key(secp);
             let reskey = res.combine(&addr.get_m_pubkey())?;
             let (reskey_xonly, _) = reskey.x_only_public_key();
 
-            let entry = result.entry(addr).or_default();
-            entry.push(reskey_xonly);
+            result.entry(addr).or_default().push(reskey_xonly);
         }
     }
     Ok(result)

--- a/silentpayments/src/sending.rs
+++ b/silentpayments/src/sending.rs
@@ -13,10 +13,10 @@ use std::collections::HashMap;
 
 use crate::utils::common::calculate_t_n;
 use crate::utils::common::SharedSecret;
+use crate::utils::common::SilentPaymentAddressRaw;
 use crate::utils::sending::calculate_ecdh_shared_secret;
 use crate::utils::sending::PartialSecret;
 use crate::Result;
-use crate::SilentPaymentAddress;
 
 /// Create outputs for a given set of silent payment recipients and their corresponding shared secrets.
 ///
@@ -26,7 +26,7 @@ use crate::SilentPaymentAddress;
 ///
 /// # Arguments
 ///
-/// * `recipients` - A [Vec] of silent payment addresses strings to be paid.
+/// * `recipients` - A [Vec] of silent payment addresses to be paid.
 /// * `partial_secret` - [PartialSecret] that represents the sum of the private keys of eligible inputs of the transaction multiplied by the input hash.
 ///
 /// # Returns
@@ -38,29 +38,31 @@ use crate::SilentPaymentAddress;
 ///
 /// This function will return an error if:
 ///
-/// * The recipients [Vec] contains a silent payment address with an incorrect format.
 /// * Edge cases are hit during elliptic curve computation (extremely unlikely).
 pub fn generate_recipient_pubkeys(
-    recipients: Vec<SilentPaymentAddress>,
+    recipients: Vec<SilentPaymentAddressRaw>,
     partial_secret: PartialSecret,
-) -> Result<HashMap<SilentPaymentAddress, Vec<XOnlyPublicKey>>> {
+) -> Result<HashMap<SilentPaymentAddressRaw, Vec<XOnlyPublicKey>>> {
     let secp = Secp256k1::new();
 
-    let mut silent_payment_groups: HashMap<PublicKey, (SharedSecret, Vec<SilentPaymentAddress>)> =
-        HashMap::new();
+    let mut silent_payment_groups: HashMap<
+        PublicKey,
+        (SharedSecret, Vec<SilentPaymentAddressRaw>),
+    > = HashMap::new();
     for address in recipients {
-        let B_scan = address.get_scan_key();
+        let recipient_scan_key = address.get_scan_pubkey();
 
-        if let Some((_, payments)) = silent_payment_groups.get_mut(&B_scan) {
+        if let Some((_, payments)) = silent_payment_groups.get_mut(&recipient_scan_key) {
             payments.push(address);
         } else {
-            let ecdh_shared_secret = calculate_ecdh_shared_secret(&B_scan, &partial_secret);
+            let ecdh_shared_secret =
+                calculate_ecdh_shared_secret(&recipient_scan_key, &partial_secret);
 
-            silent_payment_groups.insert(B_scan, (ecdh_shared_secret, vec![address]));
+            silent_payment_groups.insert(recipient_scan_key, (ecdh_shared_secret, vec![address]));
         }
     }
 
-    let mut result: HashMap<SilentPaymentAddress, Vec<XOnlyPublicKey>> = HashMap::new();
+    let mut result: HashMap<SilentPaymentAddressRaw, Vec<XOnlyPublicKey>> = HashMap::new();
     for group in silent_payment_groups.into_values() {
         let (ecdh_shared_secret, recipients) = group;
 
@@ -68,7 +70,7 @@ pub fn generate_recipient_pubkeys(
             let t_n = calculate_t_n(&ecdh_shared_secret, n as u32)?;
 
             let res = t_n.public_key(&secp);
-            let reskey = res.combine(&addr.get_spend_key())?;
+            let reskey = res.combine(&addr.get_m_pubkey())?;
             let (reskey_xonly, _) = reskey.x_only_public_key();
 
             let entry = result.entry(addr).or_default();

--- a/silentpayments/src/utils.rs
+++ b/silentpayments/src/utils.rs
@@ -4,10 +4,10 @@
 //! than the basic sending and receiving logic.
 #[cfg(any(feature = "sending", feature = "receiving"))]
 pub(crate) mod hash;
-#[cfg(any(feature = "sending", feature = "receiving"))]
-pub(crate) mod script;
 #[cfg(feature = "receiving")]
 pub mod receiving;
+#[cfg(any(feature = "sending", feature = "receiving"))]
+pub(crate) mod script;
 #[cfg(feature = "sending")]
 pub mod sending;
 

--- a/silentpayments/src/utils.rs
+++ b/silentpayments/src/utils.rs
@@ -4,6 +4,8 @@
 //! than the basic sending and receiving logic.
 #[cfg(any(feature = "sending", feature = "receiving"))]
 pub(crate) mod hash;
+#[cfg(any(feature = "sending", feature = "receiving"))]
+pub(crate) mod script;
 #[cfg(feature = "receiving")]
 pub mod receiving;
 #[cfg(feature = "sending")]

--- a/silentpayments/src/utils.rs
+++ b/silentpayments/src/utils.rs
@@ -8,7 +8,10 @@ pub(crate) mod hash;
 pub mod receiving;
 #[cfg(any(feature = "sending", feature = "receiving"))]
 pub(crate) mod script;
-#[cfg(feature = "sending")]
+#[cfg(all(
+    feature = "sending",
+    any(feature = "dleq-standalone", feature = "dleq-native")
+))]
 pub mod sending;
 
 pub(crate) mod common;

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -20,6 +20,8 @@ use serde::Deserializer;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+pub const SILENT_PAYMENT_ADDRESS_BYTE_LEN: usize = 67;
+
 /// Struct representing an OutPoint type.
 ///
 /// This can be constructed from a rust-bitcoin outpoint:
@@ -248,6 +250,24 @@ impl SilentPaymentAddress {
     /// Get the version byte.
     pub fn get_version(&self) -> u8 {
         self.version.into()
+    }
+
+    pub fn to_byte_array(&self) -> [u8; SILENT_PAYMENT_ADDRESS_BYTE_LEN] {
+        let mut bytes = [0u8; SILENT_PAYMENT_ADDRESS_BYTE_LEN];
+        bytes[0] = self.version.into();
+        bytes[1..34].copy_from_slice(&self.scan_pubkey.serialize());
+        bytes[34..67].copy_from_slice(&self.m_pubkey.serialize());
+        bytes
+    }
+
+    pub fn try_from_byte_array(
+        bytes: &[u8; SILENT_PAYMENT_ADDRESS_BYTE_LEN],
+        network: Network,
+    ) -> Result<Self> {
+        let version: SpVersion = bytes[0].try_into()?;
+        let scan_pubkey = PublicKey::from_slice(&bytes[1..34])?;
+        let m_pubkey = PublicKey::from_slice(&bytes[34..])?;
+        Ok(Self::new(scan_pubkey, m_pubkey, network, version))
     }
 }
 

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -3,6 +3,8 @@ use core::fmt;
 
 #[cfg(any(feature = "sending", feature = "receiving"))]
 use crate::utils::hash::SharedSecretHash;
+#[cfg(any(feature = "sending", feature = "receiving"))]
+use crate::utils::script::is_eligible;
 use crate::Error;
 #[cfg(any(feature = "sending", feature = "receiving"))]
 use crate::Result;
@@ -65,6 +67,96 @@ impl OutPoint {
 
     pub fn to_bytes(&self) -> [u8; 36] {
         self.0
+    }
+}
+
+/// Parallel per-vin input data for BIP352 shared secret derivation.
+///
+/// All fields are indexed by input vin. Use [`Self::new`] and [`Self::push`] when building
+/// from chain data.
+#[cfg(any(feature = "sending", feature = "receiving"))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransactionInputs {
+    outpoints: Vec<OutPoint>,
+    script_pubkeys: Vec<Vec<u8>>,
+    input_pubkeys: Vec<Option<PublicKey>>,
+}
+
+#[cfg(any(feature = "sending", feature = "receiving"))]
+impl TransactionInputs {
+    /// Create an empty input set for incremental construction.
+    pub fn new() -> Self {
+        Self {
+            outpoints: Vec::new(),
+            script_pubkeys: Vec::new(),
+            input_pubkeys: Vec::new(),
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            outpoints: Vec::with_capacity(capacity),
+            script_pubkeys: Vec::with_capacity(capacity),
+            input_pubkeys: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Append one transaction input.
+    pub fn push(
+        &mut self,
+        outpoint: OutPoint,
+        script_pubkey: Vec<u8>,
+        input_pubkey: Option<PublicKey>,
+    ) {
+        self.outpoints.push(outpoint);
+        self.script_pubkeys.push(script_pubkey);
+        self.input_pubkeys.push(input_pubkey);
+    }
+
+    pub fn len(&self) -> usize {
+        self.outpoints.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.outpoints.is_empty()
+    }
+
+    pub fn outpoints(&self) -> &[OutPoint] {
+        &self.outpoints
+    }
+
+    pub fn script_pubkeys(&self) -> &[Vec<u8>] {
+        &self.script_pubkeys
+    }
+
+    pub fn input_pubkeys(&self) -> &[Option<PublicKey>] {
+        &self.input_pubkeys
+    }
+
+    pub fn input_pubkey(&self, vin: usize) -> Option<&PublicKey> {
+        self.input_pubkeys.get(vin).and_then(|pk| pk.as_ref())
+    }
+
+    pub(crate) fn min_outpoint(&self) -> &OutPoint {
+        self.outpoints.iter().min().expect("non-empty")
+    }
+
+    pub(crate) fn eligible_pubkeys(&self) -> Result<Vec<&PublicKey>> {
+        let eligible: Vec<&PublicKey> = self
+            .script_pubkeys
+            .iter()
+            .zip(&self.input_pubkeys)
+            .filter_map(|(spk, pk)| pk.as_ref().filter(|_| is_eligible(spk)))
+            .collect();
+        if eligible.is_empty() {
+            return Err(Error::GenericError("No eligible input pubkeys".to_owned()));
+        }
+        Ok(eligible)
+    }
+
+    pub(crate) fn eligible_pubkeys_sum(&self) -> Result<PublicKey> {
+        let eligible_pubkeys = self.eligible_pubkeys()?;
+        Ok(PublicKey::combine_keys(&eligible_pubkeys)?)
     }
 }
 

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -1,12 +1,27 @@
 #[cfg(feature = "encode")]
 use core::fmt;
+#[cfg(all(
+    feature = "sending",
+    any(feature = "dleq-standalone", feature = "dleq-native")
+))]
+use std::collections::HashSet;
 
+#[cfg(all(
+    feature = "sending",
+    any(feature = "dleq-standalone", feature = "dleq-native")
+))]
+use crate::utils::hash::calculate_input_hash;
 #[cfg(any(feature = "sending", feature = "receiving"))]
 use crate::utils::hash::calculate_shared_secret_hash;
 #[cfg(feature = "receiving")]
 use crate::utils::receiving::PublicTweakData;
 #[cfg(any(feature = "sending", feature = "receiving"))]
 use crate::utils::script::is_eligible;
+#[cfg(all(
+    feature = "sending",
+    any(feature = "dleq-standalone", feature = "dleq-native")
+))]
+use crate::utils::sending::{GlobalSenderEcdhShare, PartialSenderEcdhShare};
 #[cfg(any(feature = "sending", feature = "receiving"))]
 use crate::Error;
 #[cfg(any(feature = "sending", feature = "receiving"))]
@@ -153,6 +168,19 @@ impl TransactionInputs {
         Ok(eligible)
     }
 
+    #[cfg(all(
+        feature = "sending",
+        any(feature = "dleq-standalone", feature = "dleq-native")
+    ))]
+    pub fn eligible_vins(&self) -> HashSet<usize> {
+        self.script_pubkeys
+            .iter()
+            .zip(&self.input_pubkeys)
+            .enumerate()
+            .filter_map(|(vin, (spk, pk))| (pk.is_some() && is_eligible(spk)).then_some(vin))
+            .collect()
+    }
+
     pub(crate) fn eligible_pubkeys_sum(&self) -> Result<PublicKey> {
         let eligible_pubkeys = self.eligible_pubkeys()?;
         Ok(PublicKey::combine_keys(&eligible_pubkeys)?)
@@ -206,6 +234,102 @@ impl TransactionSharedSecret {
             ecdh_shared_secret,
             recipient_scan_key,
         }
+    }
+
+    /// Create a shared secret from a finalized global ECDH share (sender path).
+    #[cfg(all(
+        feature = "sending",
+        any(feature = "dleq-standalone", feature = "dleq-native")
+    ))]
+    pub fn new_from_global_share<C: secp256k1::Signing + secp256k1::Verification>(
+        secp: &Secp256k1<C>,
+        global_share: &GlobalSenderEcdhShare,
+        inputs: &TransactionInputs,
+    ) -> Result<Self> {
+        let eligible_pubkeys = inputs.eligible_pubkeys()?;
+        global_share.verify_dleq_proof(secp, NonEmptyArray::new(&eligible_pubkeys)?)?;
+        let input_hash =
+            calculate_input_hash(inputs.min_outpoint(), inputs.eligible_pubkeys_sum()?);
+        let tweaked_share = global_share
+            .as_ecdh_shared_secret()
+            .mul_tweak(secp, &input_hash)?;
+        Ok(Self {
+            ecdh_shared_secret: tweaked_share,
+            recipient_scan_key: *global_share.recipient_scan_key(),
+        })
+    }
+
+    /// Create a shared secret by summing hashed partial ECDH shares (multi-signer sender path).
+    ///
+    /// Every SP-eligible input in the transaction (i.e. every vin where the script type is
+    /// eligible and a pubkey was extracted) must have a corresponding partial share. Missing
+    /// or extra shares are rejected so the `input_hash` is computed over the same pubkey set
+    /// as the receiver uses.
+    #[cfg(all(
+        feature = "sending",
+        any(feature = "dleq-standalone", feature = "dleq-native")
+    ))]
+    pub fn new_from_partial_shares<C: secp256k1::Signing + secp256k1::Verification>(
+        secp: &Secp256k1<C>,
+        recipient_scan_key: PublicKey,
+        partial_shares: NonEmptyArray<PartialSenderEcdhShare>,
+        inputs: &TransactionInputs,
+    ) -> Result<Self> {
+        let eligible_vins = inputs.eligible_vins();
+
+        let mut partial_vins: HashSet<usize> =
+            HashSet::with_capacity(partial_shares.as_inner().len());
+        for share in partial_shares.as_inner().iter() {
+            if *share.recipient_scan_key() != recipient_scan_key {
+                return Err(Error::GenericError(format!(
+                    "Unexpected recipient scan key for share vin {}: {}",
+                    share.input_vin(),
+                    share.recipient_scan_key(),
+                )));
+            }
+            if !partial_vins.insert(share.input_vin()) {
+                return Err(Error::GenericError(format!(
+                    "Input vin {} already seen",
+                    share.input_vin()
+                )));
+            }
+        }
+
+        if partial_vins != eligible_vins {
+            let mut missing: Vec<usize> =
+                eligible_vins.difference(&partial_vins).copied().collect();
+            missing.sort_unstable();
+            let mut unexpected: Vec<usize> =
+                partial_vins.difference(&eligible_vins).copied().collect();
+            unexpected.sort_unstable();
+            return Err(Error::GenericError(format!(
+                "Partial share coverage mismatch. \
+                 Missing shares for eligible vins: {:?}. \
+                 Shares for non-eligible vins: {:?}",
+                missing, unexpected
+            )));
+        }
+
+        let mut shares_to_sum: Vec<&PublicKey> =
+            Vec::with_capacity(partial_shares.as_inner().len());
+        for share in partial_shares.as_inner().iter() {
+            let vin = share.input_vin();
+            let pubkey = inputs
+                .input_pubkey(vin)
+                .expect("partial vin is eligible and has pubkey");
+            share.verify_dleq_proof(secp, pubkey)?;
+            shares_to_sum.push(share.as_ecdh_shared_secret());
+        }
+
+        let input_hash =
+            calculate_input_hash(inputs.min_outpoint(), inputs.eligible_pubkeys_sum()?);
+        let tweaked_share =
+            PublicKey::combine_keys(&shares_to_sum)?.mul_tweak(secp, &input_hash)?;
+
+        Ok(Self {
+            ecdh_shared_secret: tweaked_share,
+            recipient_scan_key,
+        })
     }
 
     /// Calculate the shared secret of a transaction as a receiver.
@@ -502,7 +626,7 @@ impl From<SilentPaymentAddress> for String {
     }
 }
 
-pub(crate) struct NonEmptyArray<'a, T>(&'a [T]);
+pub struct NonEmptyArray<'a, T>(&'a [T]);
 
 impl<'a, T> NonEmptyArray<'a, T> {
     pub fn new(arr: &'a [T]) -> crate::Result<Self> {

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -227,17 +227,6 @@ pub struct TransactionSharedSecret {
 }
 
 impl TransactionSharedSecret {
-    #[cfg(feature = "sending")]
-    pub(crate) fn from_sender_ecdh(
-        ecdh_shared_secret: PublicKey,
-        recipient_scan_key: PublicKey,
-    ) -> Self {
-        Self {
-            ecdh_shared_secret,
-            recipient_scan_key,
-        }
-    }
-
     /// Create a shared secret from a finalized global ECDH share (sender path).
     #[cfg(all(
         feature = "sending",

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -2,19 +2,19 @@
 use core::fmt;
 
 #[cfg(any(feature = "sending", feature = "receiving"))]
-use crate::utils::hash::SharedSecretHash;
+use crate::utils::hash::calculate_shared_secret_hash;
+#[cfg(feature = "receiving")]
+use crate::utils::receiving::PublicTweakData;
 #[cfg(any(feature = "sending", feature = "receiving"))]
 use crate::utils::script::is_eligible;
+#[cfg(any(feature = "sending", feature = "receiving"))]
 use crate::Error;
 #[cfg(any(feature = "sending", feature = "receiving"))]
 use crate::Result;
 #[cfg(feature = "encode")]
 use bech32::{FromBase32, ToBase32};
 #[cfg(any(feature = "sending", feature = "receiving"))]
-use bitcoin_hashes::Hash;
-use secp256k1::PublicKey;
-#[cfg(any(feature = "sending", feature = "receiving"))]
-use secp256k1::{Scalar, Secp256k1, SecretKey};
+use secp256k1::{ecdh::shared_secret_point, PublicKey, Scalar, Secp256k1, SecretKey};
 #[cfg(all(feature = "serde", feature = "encode"))]
 use serde::ser::Serializer;
 #[cfg(all(feature = "serde", feature = "encode"))]
@@ -92,7 +92,6 @@ impl TransactionInputs {
             input_pubkeys: Vec::new(),
         }
     }
-
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             outpoints: Vec::with_capacity(capacity),
@@ -160,13 +159,96 @@ impl TransactionInputs {
     }
 }
 
+/// Compute `private_key * public_key` as a secp256k1 [`PublicKey`].
+///
+/// # Arguments
+///
+/// * `public_key` - Either the recipient scan public key (sender) or the sum of all eligible inputs public keys (recipient).
+/// * `private_key` - Either one or all private keys used in the inputs of the transaction (sender) or the private scan key (recipient).
+///
+/// # Returns
+///
+/// The shared secret as a [`PublicKey`].
+///
+/// # Errors
+///
+/// This function will error if:
+///
+/// * The elliptic curve computation results in an invalid public key.
+///
+/// Uses `shared_secret_point` for constant-time scalar multiplication.
+#[cfg(any(feature = "sending", feature = "receiving"))]
+pub(crate) fn ecdh_multiply(public_key: &PublicKey, private_key: &SecretKey) -> Result<PublicKey> {
+    let mut ss_bytes = [0u8; 65];
+    ss_bytes[0] = 0x04;
+    ss_bytes[1..].copy_from_slice(&shared_secret_point(public_key, private_key));
+    Ok(PublicKey::from_slice(&ss_bytes)?)
+}
+
+/// Represents the shared secret, one for each scan key in the outputs, which is either obtained from
+/// * sum of all eligible inputs private keys multiplied with the input hash, multiplied with the scan public key, or
+/// * sum of all eligible inputs public keys multiplied with the input hash, multiplied with the scan private key
+/// Since sender and recipient are supposed to end up with the same shared secret, this is the final type used for both.
 #[cfg(any(feature = "sending", feature = "receiving"))]
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
-pub struct SharedSecret(pub(crate) PublicKey);
+pub struct TransactionSharedSecret {
+    ecdh_shared_secret: PublicKey,
+    recipient_scan_key: PublicKey,
+}
+
+impl TransactionSharedSecret {
+    #[cfg(feature = "sending")]
+    pub(crate) fn from_sender_ecdh(
+        ecdh_shared_secret: PublicKey,
+        recipient_scan_key: PublicKey,
+    ) -> Self {
+        Self {
+            ecdh_shared_secret,
+            recipient_scan_key,
+        }
+    }
+
+    /// Calculate the shared secret of a transaction as a receiver.
+    ///
+    /// # Arguments
+    ///
+    /// * `tweak_data` - The tweak data of the transaction, see [`PublicTweakData::new`].
+    /// * `recipient_scan_key` - The scan private key used by the wallet.
+    ///
+    /// # Returns
+    ///
+    /// This function returns the shared secret of this transaction. This shared secret can be used to scan the transaction of outputs that are for the current user. See [`Receiver::scan_transaction`](crate::receiving::Receiver::scan_transaction).
+    #[cfg(feature = "receiving")]
+    pub fn new_from_public_tweak_data<C: secp256k1::Signing>(
+        secp: &Secp256k1<C>,
+        tweak_data: &PublicTweakData,
+        recipient_scan_key: &SecretKey,
+    ) -> Result<Self> {
+        Ok(Self {
+            ecdh_shared_secret: ecdh_multiply(tweak_data.as_inner(), recipient_scan_key)?,
+            recipient_scan_key: PublicKey::from_secret_key(&secp, recipient_scan_key),
+        })
+    }
+
+    pub fn as_ecdh_shared_secret(&self) -> &PublicKey {
+        &self.ecdh_shared_secret
+    }
+
+    pub fn into_ecdh_shared_secret(self) -> PublicKey {
+        self.ecdh_shared_secret
+    }
+
+    pub fn as_recipient_scan_key(&self) -> &PublicKey {
+        &self.recipient_scan_key
+    }
+}
 
 #[cfg(any(feature = "sending", feature = "receiving"))]
-pub(crate) fn calculate_t_n(ecdh_shared_secret: &SharedSecret, k: u32) -> Result<SecretKey> {
-    let hash = SharedSecretHash::from_ecdh_and_k(ecdh_shared_secret, k).to_byte_array();
+pub(crate) fn calculate_t_n(
+    ecdh_shared_secret: &TransactionSharedSecret,
+    k: u32,
+) -> Result<SecretKey> {
+    let hash = calculate_shared_secret_hash(ecdh_shared_secret, k);
     let sk = SecretKey::from_slice(&hash)?;
 
     Ok(sk)

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -153,6 +153,69 @@ impl TryFrom<u8> for SpVersion {
     }
 }
 
+/// A wrapper around a byte array that represents a valid silent payment address without network.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub struct SilentPaymentAddressRaw([u8; SILENT_PAYMENT_ADDRESS_BYTE_LEN]);
+
+impl SilentPaymentAddressRaw {
+    pub fn new(version: SpVersion, scan_pubkey: PublicKey, m_pubkey: PublicKey) -> Self {
+        let mut bytes = [0u8; SILENT_PAYMENT_ADDRESS_BYTE_LEN];
+        bytes[0] = version.into();
+        bytes[1..34].copy_from_slice(&scan_pubkey.serialize());
+        bytes[34..67].copy_from_slice(&m_pubkey.serialize());
+        Self(bytes)
+    }
+
+    pub fn new_from_address(address: &SilentPaymentAddress) -> Self {
+        Self::try_from_byte_array(&address.to_byte_array())
+            .expect("We did the same check than SilentPaymentAddress")
+    }
+
+    pub fn to_address_for_network(&self, network: Network) -> SilentPaymentAddress {
+        SilentPaymentAddress::try_from_byte_array(&self.0, network)
+            .expect("We did the same check than SilentPaymentAddress")
+    }
+
+    pub fn as_inner(&self) -> &[u8; SILENT_PAYMENT_ADDRESS_BYTE_LEN] {
+        &self.0
+    }
+
+    pub fn to_inner(&self) -> [u8; SILENT_PAYMENT_ADDRESS_BYTE_LEN] {
+        self.0
+    }
+
+    pub fn try_from_byte_array(bytes: &[u8; SILENT_PAYMENT_ADDRESS_BYTE_LEN]) -> Result<Self> {
+        let version: SpVersion = bytes[0].try_into()?;
+        let scan_pubkey = PublicKey::from_slice(&bytes[1..34])?;
+        let m_pubkey = PublicKey::from_slice(&bytes[34..])?;
+        Ok(Self::new(version, scan_pubkey, m_pubkey))
+    }
+
+    pub fn get_version(&self) -> SpVersion {
+        self.0[0]
+            .try_into()
+            .expect("We did the same check than SilentPaymentAddress")
+    }
+
+    pub fn get_scan_pubkey(&self) -> PublicKey {
+        PublicKey::from_slice(&self.0[1..34])
+            .expect("We did the same check than SilentPaymentAddress")
+    }
+
+    pub fn get_m_pubkey(&self) -> PublicKey {
+        PublicKey::from_slice(&self.0[34..])
+            .expect("We did the same check than SilentPaymentAddress")
+    }
+
+    pub fn scan_pubkey_as_slice(&self) -> &[u8] {
+        &self.0[1..34]
+    }
+
+    pub fn m_pubkey_as_slice(&self) -> &[u8] {
+        &self.0[34..]
+    }
+}
+
 /// A silent payment address struct that can be used to deserialize a silent payment address string.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct SilentPaymentAddress {

--- a/silentpayments/src/utils/hash.rs
+++ b/silentpayments/src/utils/hash.rs
@@ -1,15 +1,15 @@
-use crate::utils::common::{NonEmptyArray, OutPoint, SharedSecret};
+use crate::utils::common::{OutPoint, SharedSecret};
 use bitcoin_hashes::{sha256t_hash_newtype, Hash, HashEngine};
 use secp256k1::{PublicKey, Scalar, SecretKey};
 
 sha256t_hash_newtype! {
-    pub(crate) struct InputsTag = hash_str("BIP0352/Inputs");
+    struct InputsTag = hash_str("BIP0352/Inputs");
 
     /// BIP0352-tagged hash with tag \"Inputs\".
     ///
     /// This is used for computing the inputs hash.
     #[hash_newtype(forward)]
-    pub(crate) struct InputsHash(_);
+    struct InputsHash(_);
 
     pub(crate) struct LabelTag = hash_str("BIP0352/Label");
 
@@ -29,16 +29,14 @@ sha256t_hash_newtype! {
 }
 
 impl InputsHash {
-    pub(crate) fn from_outpoint_and_A_sum(
-        smallest_outpoint: &OutPoint,
-        A_sum: PublicKey,
-    ) -> InputsHash {
+    fn from_outpoint_and_A_sum(smallest_outpoint: &OutPoint, A_sum: PublicKey) -> InputsHash {
         let mut eng = InputsHash::engine();
         eng.input(&smallest_outpoint.0);
         eng.input(&A_sum.serialize());
         InputsHash::from_engine(eng)
     }
-    pub(crate) fn to_scalar(self) -> Scalar {
+
+    fn to_scalar(self) -> Scalar {
         // This is statistically extremely unlikely to panic.
         Scalar::from_be_bytes(self.to_byte_array()).expect("hash value greater than curve order")
     }
@@ -67,9 +65,6 @@ impl SharedSecretHash {
     }
 }
 
-pub(crate) fn calculate_input_hash(
-    outpoints_data: NonEmptyArray<OutPoint>,
-    A_sum: PublicKey,
-) -> Scalar {
-    InputsHash::from_outpoint_and_A_sum(outpoints_data.min(), A_sum).to_scalar()
+pub(crate) fn calculate_input_hash(smaller_outpoint: &OutPoint, A_sum: PublicKey) -> Scalar {
+    InputsHash::from_outpoint_and_A_sum(smaller_outpoint, A_sum).to_scalar()
 }

--- a/silentpayments/src/utils/hash.rs
+++ b/silentpayments/src/utils/hash.rs
@@ -1,4 +1,4 @@
-use crate::utils::common::{OutPoint, SharedSecret};
+use crate::utils::common::{OutPoint, TransactionSharedSecret};
 use bitcoin_hashes::{sha256t_hash_newtype, Hash, HashEngine};
 use secp256k1::{PublicKey, Scalar, SecretKey};
 
@@ -11,13 +11,13 @@ sha256t_hash_newtype! {
     #[hash_newtype(forward)]
     struct InputsHash(_);
 
-    pub(crate) struct LabelTag = hash_str("BIP0352/Label");
+    struct LabelTag = hash_str("BIP0352/Label");
 
     /// BIP0352-tagged hash with tag \"Label\".
     ///
     /// This is used for computing the label tweak.
     #[hash_newtype(forward)]
-    pub(crate) struct LabelHash(_);
+    struct LabelHash(_);
 
     pub(crate) struct SharedSecretTag = hash_str("BIP0352/SharedSecret");
 
@@ -57,14 +57,22 @@ impl LabelHash {
 }
 
 impl SharedSecretHash {
-    pub(crate) fn from_ecdh_and_k(ecdh: &SharedSecret, k: u32) -> SharedSecretHash {
+    pub(crate) fn from_ecdh_and_k(ecdh: &TransactionSharedSecret, k: u32) -> SharedSecretHash {
         let mut eng = SharedSecretHash::engine();
-        eng.input(&ecdh.0.serialize());
+        eng.input(&ecdh.as_ecdh_shared_secret().serialize());
         eng.input(&k.to_be_bytes());
         SharedSecretHash::from_engine(eng)
     }
 }
 
 pub(crate) fn calculate_input_hash(smaller_outpoint: &OutPoint, A_sum: PublicKey) -> Scalar {
-    InputsHash::from_outpoint_and_A_sum(smaller_outpoint, A_sum).to_scalar()
+    InputsHash::from_outpoint_and_A_sum(&smaller_outpoint, A_sum).to_scalar()
+}
+
+pub(crate) fn calculate_label_hash(b_scan: SecretKey, m: u32) -> Scalar {
+    LabelHash::from_b_scan_and_m(b_scan, m).to_scalar()
+}
+
+pub(crate) fn calculate_shared_secret_hash(ecdh: &TransactionSharedSecret, k: u32) -> [u8; 32] {
+    SharedSecretHash::from_ecdh_and_k(ecdh, k).to_byte_array()
 }

--- a/silentpayments/src/utils/receiving.rs
+++ b/silentpayments/src/utils/receiving.rs
@@ -2,8 +2,7 @@
 use crate::{
     utils::{
         common::{NonEmptyArray, OutPoint, SharedSecret},
-        OP_0, OP_1, OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160, OP_PUSHBYTES_20,
-        OP_PUSHBYTES_32,
+        script::{is_p2pkh, is_p2sh, is_p2wpkh},
     },
     Error, Result,
 };
@@ -15,7 +14,56 @@ use secp256k1::{PublicKey, SecretKey};
 
 use super::{hash::calculate_input_hash, COMPRESSED_PUBKEY_SIZE, NUMS_H};
 
-/// Calculate the tweak data of a transaction.
+/// Returns the last data push in a push-only script, or `None` if malformed.
+fn last_push(script: &[u8]) -> Option<&[u8]> {
+    let mut i = 0;
+    let mut last: Option<&[u8]> = None;
+    while i < script.len() {
+        let op = script[i];
+        i += 1;
+        let (extra_len_bytes, data_len): (usize, usize) = match op {
+            0x01..=0x4b => (0, op as usize),
+            0x4c => (1, *script.get(i)? as usize),
+            0x4d => {
+                let lo = *script.get(i)? as usize;
+                let hi = *script.get(i + 1)? as usize;
+                (2, lo | (hi << 8))
+            }
+            0x4e => {
+                let b0 = *script.get(i)? as usize;
+                let b1 = *script.get(i + 1)? as usize;
+                let b2 = *script.get(i + 2)? as usize;
+                let b3 = *script.get(i + 3)? as usize;
+                (4, b0 | (b1 << 8) | (b2 << 16) | (b3 << 24))
+            }
+            _ => return None,
+        };
+        i += extra_len_bytes;
+        last = Some(script.get(i..i + data_len)?);
+        i += data_len;
+    }
+    last
+}
+
+/// Parse a compressed witness pubkey and verify it matches the expected hash160.
+fn witness_compressed_pubkey(
+    witness_last: &[u8],
+    expected_hash: &[u8],
+) -> Result<Option<PublicKey>> {
+    if witness_last.len() != COMPRESSED_PUBKEY_SIZE {
+        return Ok(None);
+    }
+    let pubkey = match PublicKey::from_slice(witness_last) {
+        Ok(pk) => pk,
+        Err(_) => return Ok(None),
+    };
+    if hash160::Hash::hash(witness_last).to_byte_array() != expected_hash {
+        return Ok(None);
+    }
+    Ok(Some(pubkey))
+}
+
+/// Public tweak data for a transaction: `input_hash * sum(eligible input pubkeys)`.
 ///
 /// This is useful in combination with the [calculate_ecdh_shared_secret] function, but can also be used
 /// by indexing servers that don't have access to the recipient scan key.
@@ -120,25 +168,15 @@ pub fn get_pubkey_from_input(
     } else if is_p2sh(script_pub_key) {
         match (txinwitness.is_empty(), script_sig.is_empty()) {
             (false, false) => {
-                let redeem_script = &script_sig[1..];
+                let Some(redeem_script) = last_push(script_sig) else {
+                    return Ok(None);
+                };
+                if hash160::Hash::hash(redeem_script).to_byte_array() != script_pub_key[2..22] {
+                    return Ok(None);
+                }
                 if is_p2wpkh(redeem_script) {
                     if let Some(value) = txinwitness.last() {
-                        match (
-                            PublicKey::from_slice(value),
-                            value.len() == COMPRESSED_PUBKEY_SIZE,
-                        ) {
-                            (Ok(pubkey), true) => {
-                                return Ok(Some(pubkey));
-                            }
-                            (_, false) => {
-                                return Ok(None);
-                            }
-                            // Not sure how we could get an error here, so just return none for now
-                            // if the pubkey cant be parsed
-                            (Err(_), _) => {
-                                return Ok(None);
-                            }
-                        }
+                        return witness_compressed_pubkey(value, &redeem_script[2..22]);
                     }
                 }
             }
@@ -153,22 +191,7 @@ pub fn get_pubkey_from_input(
         match (txinwitness.is_empty(), script_sig.is_empty()) {
             (false, true) => {
                 if let Some(value) = txinwitness.last() {
-                    match (
-                        PublicKey::from_slice(value),
-                        value.len() == COMPRESSED_PUBKEY_SIZE,
-                    ) {
-                        (Ok(pubkey), true) => {
-                            return Ok(Some(pubkey));
-                        }
-                        (_, false) => {
-                            return Ok(None);
-                        }
-                        // Not sure how we could get an error here, so just return none for now
-                        // if the pubkey cant be parsed
-                        (Err(_), _) => {
-                            return Ok(None);
-                        }
-                    }
+                    return witness_compressed_pubkey(value, &script_pub_key[2..22]);
                 } else {
                     return Err(Error::InvalidVin("Empty witness".to_owned()));
                 }
@@ -194,10 +217,14 @@ pub fn get_pubkey_from_input(
                     None => return Err(Error::InvalidVin("Empty or invalid witness".to_owned())),
                 };
 
-                // Check for script path
                 let stack_size = txinwitness.len();
-                if stack_size > annex && txinwitness[stack_size - annex - 1][1..33] == NUMS_H {
-                    return Ok(None);
+                let effective_stack = stack_size - annex;
+                // Script path: control block is the last effective witness item.
+                if effective_stack >= 2 {
+                    let control_block = &txinwitness[stack_size - annex - 1];
+                    if control_block.len() >= 33 && control_block[1..33] == NUMS_H {
+                        return Ok(None);
+                    }
                 }
 
                 // Return the pubkey from the script pubkey

--- a/silentpayments/src/utils/receiving.rs
+++ b/silentpayments/src/utils/receiving.rs
@@ -1,7 +1,8 @@
 //! Receiving utility functions.
 use crate::{
     utils::{
-        common::{NonEmptyArray, OutPoint, SharedSecret},
+        common::TransactionInputs,
+        hash::calculate_input_hash,
         script::{is_p2pkh, is_p2sh, is_p2wpkh},
     },
     Error, Result,
@@ -9,10 +10,10 @@ use crate::{
 
 pub use crate::utils::script::{is_eligible, is_p2tr};
 use bitcoin_hashes::{hash160, Hash};
-use secp256k1::{ecdh::shared_secret_point, Parity::Even, XOnlyPublicKey};
-use secp256k1::{PublicKey, SecretKey};
+use secp256k1::PublicKey;
+use secp256k1::{Parity::Even, Secp256k1, Verification, XOnlyPublicKey};
 
-use super::{hash::calculate_input_hash, COMPRESSED_PUBKEY_SIZE, NUMS_H};
+use super::{COMPRESSED_PUBKEY_SIZE, NUMS_H};
 
 /// Returns the last data push in a push-only script, or `None` if malformed.
 fn last_push(script: &[u8]) -> Option<&[u8]> {
@@ -65,56 +66,44 @@ fn witness_compressed_pubkey(
 
 /// Public tweak data for a transaction: `input_hash * sum(eligible input pubkeys)`.
 ///
-/// This is useful in combination with the [calculate_ecdh_shared_secret] function, but can also be used
-/// by indexing servers that don't have access to the recipient scan key.
-///
-/// # Arguments
-///
-/// * `input_pub_keys` - The list of public keys that are used as input for this transaction. Only the public keys for inputs that are silent payment eligible should be given.
-/// * `outpoints_data` - All prevout outpoints used as input for this transaction. Note that the txid is given in String format, which is displayed in reverse order from the inner byte array.
-///
-/// # Returns
-///
-/// This function returns the tweak data for this transaction. The tweak data is an intermediary result that can be used to calculate the final shared secret.
-///
-/// # Errors
-///
-/// This function will error if:
-///
-/// * The input public keys array is of length zero, or the summing results in an invalid key.
-/// * The outpoints_data is of length zero, or invalid.
-/// * Elliptic curve computation results in an invalid public key.
-pub fn calculate_tweak_data(
-    input_pub_keys: &[&PublicKey],
-    outpoints_data: &[OutPoint],
-) -> Result<PublicKey> {
-    let secp = secp256k1::Secp256k1::verification_only();
-    let A_sum = PublicKey::combine_keys(input_pub_keys)?;
+/// Indexing servers can publish this value so recipients can derive a
+/// [`TransactionSharedSecret`](crate::TransactionSharedSecret) locally without revealing their scan private key.
+pub struct PublicTweakData(PublicKey);
 
-    let outpoints = NonEmptyArray::new(outpoints_data)?;
-    let input_hash = calculate_input_hash(outpoints.min(), A_sum);
+impl PublicTweakData {
+    /// Construct tweak data from a value obtained from a trusted external source.
+    ///
+    /// Prefer [`Self::new`] when computing from chain data directly.
+    pub fn new_unchecked(tweak_data: PublicKey) -> Self {
+        Self(tweak_data)
+    }
 
-    Ok(A_sum.mul_tweak(&secp, &input_hash)?)
-}
+    /// Calculate the tweak data of a transaction: `input_hash * sum(eligible input pubkeys)`.
+    ///
+    /// Uses the same eligible-input rules as sender-side shared secret derivation. Combine with
+    /// [`TransactionSharedSecret::new_from_public_tweak_data`](crate::TransactionSharedSecret::new_from_public_tweak_data)
+    /// to obtain the shared secret used by [`Receiver::scan_transaction`](crate::receiving::Receiver::scan_transaction).
+    ///
+    /// # Arguments
+    ///
+    /// * `inputs` - Parallel outpoints, script pubkeys and extracted pubkeys for every vin.
+    ///
+    /// # Errors
+    ///
+    /// This function will error if:
+    ///
+    /// * `inputs` is empty.
+    /// * No eligible input pubkeys could be extracted.
+    /// * Elliptic curve computation results in an invalid public key.
+    pub fn new<C: Verification>(secp: &Secp256k1<C>, inputs: &TransactionInputs) -> Result<Self> {
+        let summed_pubkeys = inputs.eligible_pubkeys_sum()?;
+        let input_hash = calculate_input_hash(inputs.min_outpoint(), summed_pubkeys);
+        Ok(Self(summed_pubkeys.mul_tweak(secp, &input_hash)?))
+    }
 
-/// Calculate the shared secret of a transaction.
-///
-/// # Arguments
-///
-/// * `tweak_data` - The tweak data of the transaction, see `calculate_tweak_data`.
-/// * `b_scan` - The scan private key used by the wallet.
-///
-/// # Returns
-///
-/// This function returns the shared secret of this transaction. This shared secret can be used to scan the transaction of outputs that are for the current user. See [`Receiver::scan_transaction`](crate::receiving::Receiver::scan_transaction).
-pub fn calculate_ecdh_shared_secret(tweak_data: &PublicKey, b_scan: &SecretKey) -> SharedSecret {
-    let mut ss_bytes = [0u8; 65];
-    ss_bytes[0] = 0x04;
-
-    // Using `shared_secret_point` to ensure the multiplication is constant time
-    ss_bytes[1..].copy_from_slice(&shared_secret_point(tweak_data, b_scan));
-
-    SharedSecret(PublicKey::from_slice(&ss_bytes).expect("guaranteed to be a point on the curve"))
+    pub fn as_inner(&self) -> &PublicKey {
+        &self.0
+    }
 }
 
 /// Get the public keys from a set of input data.

--- a/silentpayments/src/utils/receiving.rs
+++ b/silentpayments/src/utils/receiving.rs
@@ -92,7 +92,7 @@ pub fn calculate_tweak_data(
     let A_sum = PublicKey::combine_keys(input_pub_keys)?;
 
     let outpoints = NonEmptyArray::new(outpoints_data)?;
-    let input_hash = calculate_input_hash(outpoints, A_sum);
+    let input_hash = calculate_input_hash(outpoints.min(), A_sum);
 
     Ok(A_sum.mul_tweak(&secp, &input_hash)?)
 }

--- a/silentpayments/src/utils/receiving.rs
+++ b/silentpayments/src/utils/receiving.rs
@@ -7,6 +7,8 @@ use crate::{
     },
     Error, Result,
 };
+
+pub use crate::utils::script::{is_eligible, is_p2tr};
 use bitcoin_hashes::{hash160, Hash};
 use secp256k1::{ecdh::shared_secret_point, Parity::Even, XOnlyPublicKey};
 use secp256k1::{PublicKey, SecretKey};
@@ -218,22 +220,4 @@ pub fn get_pubkey_from_input(
         }
     }
     Ok(None)
-}
-
-// script templates for inputs allowed in BIP352 shared secret derivation
-/// Check if a script_pub_key is taproot.
-pub fn is_p2tr(spk: &[u8]) -> bool {
-    matches!(spk, [OP_1, OP_PUSHBYTES_32, ..] if spk.len() == 34)
-}
-
-fn is_p2wpkh(spk: &[u8]) -> bool {
-    matches!(spk, [OP_0, OP_PUSHBYTES_20, ..] if spk.len() == 22)
-}
-
-fn is_p2sh(spk: &[u8]) -> bool {
-    matches!(spk, [OP_HASH160, OP_PUSHBYTES_20, .., OP_EQUAL] if spk.len() == 23)
-}
-
-fn is_p2pkh(spk: &[u8]) -> bool {
-    matches!(spk, [OP_DUP, OP_HASH160, OP_PUSHBYTES_20, .., OP_EQUALVERIFY, OP_CHECKSIG] if spk.len() == 25)
 }

--- a/silentpayments/src/utils/script.rs
+++ b/silentpayments/src/utils/script.rs
@@ -1,0 +1,30 @@
+//! Script template matching for silent payment-eligible inputs (BIP352).
+
+use super::{
+    OP_0, OP_1, OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160, OP_PUSHBYTES_20,
+    OP_PUSHBYTES_32,
+};
+
+/// Check if a script_pub_key is taproot.
+pub fn is_p2tr(spk: &[u8]) -> bool {
+    matches!(spk, [OP_1, OP_PUSHBYTES_32, ..] if spk.len() == 34)
+}
+
+pub(crate) fn is_p2wpkh(spk: &[u8]) -> bool {
+    matches!(spk, [OP_0, OP_PUSHBYTES_20, ..] if spk.len() == 22)
+}
+
+pub(crate) fn is_p2sh(spk: &[u8]) -> bool {
+    matches!(spk, [OP_HASH160, OP_PUSHBYTES_20, .., OP_EQUAL] if spk.len() == 23)
+}
+
+pub(crate) fn is_p2pkh(spk: &[u8]) -> bool {
+    matches!(spk, [OP_DUP, OP_HASH160, OP_PUSHBYTES_20, .., OP_EQUALVERIFY, OP_CHECKSIG] if spk.len() == 25)
+}
+
+/// Check if a script_pub_key is silent payment-eligible (BIP352 shared secret derivation).
+/// This is supposed to help as a kind of quick sanity check, but the real check must be done by the caller
+/// that have access to bitcoin crate and more context.
+pub fn is_eligible(spk: &[u8]) -> bool {
+    is_p2pkh(spk) || is_p2wpkh(spk) || is_p2sh(spk) || is_p2tr(spk)
+}

--- a/silentpayments/src/utils/sending.rs
+++ b/silentpayments/src/utils/sending.rs
@@ -50,7 +50,7 @@ pub fn calculate_partial_secret(
     let A_sum = a_sum.public_key(&secp);
 
     let outpoints = NonEmptyArray::new(outpoints_data)?;
-    let input_hash = calculate_input_hash(outpoints, A_sum);
+    let input_hash = calculate_input_hash(outpoints.min(), A_sum);
 
     Ok(PartialSecret(a_sum.mul_tweak(&input_hash)?))
 }

--- a/silentpayments/src/utils/sending.rs
+++ b/silentpayments/src/utils/sending.rs
@@ -1,8 +1,22 @@
 //! Sending utility functions.
+//!
+//! The typical flow for a single signer with DLEQ proofs is:
+//!
+//! 1. Normalize input private keys with [`NormalizedSecretKey`].
+//! 2. Create a [`GlobalSenderEcdhShare`] (single spender) or [`PartialSenderEcdhShare`]s (per input - collaborative transaction).
+//! 3. Verify BIP374 DLEQ proofs with [`PartialSenderEcdhShare::verify_dleq_proof`] /
+//!    [`GlobalSenderEcdhShare::verify_dleq_proof`].
+//! 4. Convert to a [`TransactionSharedSecret`](crate::TransactionSharedSecret), which applies the
+//!    BIP352 input hash.
+//!
+//! The legacy [`calculate_partial_secret`] / [`PartialSecret`] API remains available for callers
+//! that do not need DLEQ proofs.
+
 use crate::utils::common::{ecdh_multiply, NonEmptyArray, OutPoint, TransactionSharedSecret};
 use crate::{Error, Result};
+use rust_dleq::{generate_dleq_proof, verify_dleq_proof, DleqProof};
 use secp256k1::constants::SECRET_KEY_SIZE;
-use secp256k1::{PublicKey, Secp256k1, SecretKey, Signing};
+use secp256k1::{PublicKey, Secp256k1, SecretKey, Signing, Verification};
 
 use super::hash::calculate_input_hash;
 
@@ -31,6 +45,17 @@ impl NormalizedSecretKey {
     }
 }
 
+impl<'a> NonEmptyArray<'a, NormalizedSecretKey> {
+    pub fn sum_keys(&self) -> Result<SecretKey> {
+        let (head, tail) = self.as_inner().split_first().expect("Is non-empty");
+        tail.iter()
+            .try_fold(*head.as_inner(), |acc, item| {
+                acc.add_tweak(&(*item.as_inner()).into())
+            })
+            .map_err(Error::from)
+    }
+}
+
 /// Represents the sum of all eligible input private keys of a transaction, multiplied with the input hash.
 #[derive(Clone, Copy, Debug)]
 pub struct PartialSecret(pub(crate) SecretKey);
@@ -48,22 +73,6 @@ impl PartialSecret {
 }
 
 /// Calculate the partial secret that is needed for generating the recipient pubkeys.
-///
-/// # Arguments
-///
-/// * `input_keys` - A reference to a list of tuples, each tuple containing a [SecretKey] and [bool]. The [SecretKey] is the private key used in the input, and the [bool] indicates whether this was from a taproot address.
-/// * `outpoints_data` - The prevout outpoints used as input for this transaction. Note that the txid is given in [String] format, which is displayed in reverse order from the inner byte array.
-///
-/// # Returns
-///
-/// This function returns the partial secret, which represents the sum of all (eligible) input keys multiplied with the input hash.
-///
-/// # Errors
-///
-/// This function will error if:
-///
-/// * The input keys array is of length zero, or the summing results in an invalid key.
-/// * The outpoints_data is of length zero, or invalid.
 pub fn calculate_partial_secret(
     input_keys: &[(SecretKey, bool)],
     outpoints_data: &[OutPoint],
@@ -79,18 +88,7 @@ pub fn calculate_partial_secret(
     Ok(PartialSecret(a_sum.mul_tweak(&input_hash)?))
 }
 
-/// Calculate the shared secret of a transaction.
-///
-/// Since [generate_recipient_pubkeys](crate::sending::generate_recipient_pubkeys) calls this function internally, it is not needed for the default sending flow.
-///
-/// # Arguments
-///
-/// * `B_scan` - The scan public key used by the wallet.
-/// * `partial_secret` - the sum of all (eligible) input keys multiplied with the input hash, see [calculate_partial_secret].
-///
-/// # Returns
-///
-/// This function returns the shared secret unique to this recipient and input keys. This shared secret can be used to generate output keys for the recipient.
+/// Calculate the shared secret of a transaction from a legacy partial secret.
 pub fn calculate_ecdh_shared_secret(
     B_scan: &PublicKey,
     partial_secret: &PartialSecret,
@@ -120,4 +118,223 @@ fn get_a_sum_secret_keys(input: &[(SecretKey, bool)]) -> Result<SecretKey> {
             acc.add_tweak(&(*item.as_inner()).into())
         })
         .map_err(Error::from)
+}
+
+/// ECDH share for a single eligible input: `a_i * B_scan` (before input hash).
+///
+/// Used in multi-signer flows where each party contributes one input.
+/// Combine hashed partial shares into a [`TransactionSharedSecret`](crate::TransactionSharedSecret) via
+/// [`TransactionSharedSecret::new_from_partial_shares`](crate::TransactionSharedSecret::new_from_partial_shares).
+pub struct PartialSenderEcdhShare {
+    recipient_scan_key: PublicKey,
+    input_vin: usize,
+    ecdh_shared_secret: PublicKey,
+    dleq_proof: DleqProof,
+}
+
+impl PartialSenderEcdhShare {
+    pub fn new<C: Signing + Verification>(
+        secp: &Secp256k1<C>,
+        recipient_scan_key: PublicKey,
+        input_vin: usize,
+        private_key: &NormalizedSecretKey,
+        aux_rand: &[u8; 32],
+    ) -> Result<Self> {
+        let shared_secret = ecdh_multiply(&recipient_scan_key, private_key.as_inner())?;
+        let proof = generate_dleq_proof(
+            secp,
+            private_key.as_inner(),
+            &recipient_scan_key,
+            aux_rand,
+            None,
+        )?;
+        Ok(Self {
+            recipient_scan_key,
+            input_vin,
+            ecdh_shared_secret: shared_secret,
+            dleq_proof: proof,
+        })
+    }
+
+    pub fn new_unchecked(
+        recipient_scan_key: PublicKey,
+        input_vin: usize,
+        ecdh_shared_secret: PublicKey,
+        dleq_proof: DleqProof,
+    ) -> Self {
+        Self {
+            recipient_scan_key,
+            input_vin,
+            ecdh_shared_secret,
+            dleq_proof,
+        }
+    }
+
+    pub fn recipient_scan_key(&self) -> &PublicKey {
+        &self.recipient_scan_key
+    }
+
+    pub fn input_vin(&self) -> usize {
+        self.input_vin
+    }
+
+    pub fn as_ecdh_shared_secret(&self) -> &PublicKey {
+        &self.ecdh_shared_secret
+    }
+
+    pub fn dleq_proof(&self) -> &DleqProof {
+        &self.dleq_proof
+    }
+
+    pub fn verify_dleq_proof<C: Signing + Verification>(
+        &self,
+        secp: &Secp256k1<C>,
+        input_pubkey: &PublicKey,
+    ) -> Result<()> {
+        let is_valid = verify_dleq_proof(
+            secp,
+            input_pubkey,
+            &self.recipient_scan_key,
+            &self.ecdh_shared_secret,
+            &self.dleq_proof,
+            None,
+        )
+        .map_err(Error::from)?;
+        if !is_valid {
+            return Err(Error::GenericError("Invalid DLEQ proof".to_owned()));
+        }
+        Ok(())
+    }
+}
+
+/// ECDH share for all eligible inputs combined.
+///
+/// Built by summing private keys first ([`Self::new_from_summed_keys`]).
+/// DLEQ proofs are generated at construction time and verified before use.
+pub struct GlobalSenderEcdhShare {
+    recipient_scan_key: PublicKey,
+    ecdh_shared_secret: PublicKey,
+    dleq_proof: DleqProof,
+}
+
+impl GlobalSenderEcdhShare {
+    pub fn new_from_summed_keys<C: Signing + Verification>(
+        secp: &Secp256k1<C>,
+        recipient_scan_key: PublicKey,
+        summed_keys: NonEmptyArray<NormalizedSecretKey>,
+        aux_rand: &[u8; 32],
+    ) -> Result<Self> {
+        let secret_key = summed_keys.sum_keys()?;
+        let shared_secret = ecdh_multiply(&recipient_scan_key, &secret_key)?;
+        let proof = generate_dleq_proof(secp, &secret_key, &recipient_scan_key, aux_rand, None)?;
+        Ok(Self {
+            recipient_scan_key,
+            ecdh_shared_secret: shared_secret,
+            dleq_proof: proof,
+        })
+    }
+
+    pub fn new_unchecked(
+        recipient_scan_key: PublicKey,
+        ecdh_shared_secret: PublicKey,
+        dleq_proof: DleqProof,
+    ) -> Self {
+        Self {
+            recipient_scan_key,
+            ecdh_shared_secret,
+            dleq_proof,
+        }
+    }
+
+    /// Verify the DLEQ proof against the sum of eligible input public keys.
+    pub fn verify_dleq_proof<C: Signing + Verification>(
+        &self,
+        secp: &Secp256k1<C>,
+        input_pubkeys: NonEmptyArray<&PublicKey>,
+    ) -> Result<()> {
+        let summed_input_pubkey = PublicKey::combine_keys(input_pubkeys.as_inner())?;
+        let is_valid = verify_dleq_proof(
+            secp,
+            &summed_input_pubkey,
+            &self.recipient_scan_key,
+            &self.ecdh_shared_secret,
+            &self.dleq_proof,
+            None,
+        )
+        .map_err(Error::from)?;
+        if !is_valid {
+            return Err(Error::GenericError("Invalid DLEQ proof".to_owned()));
+        }
+        Ok(())
+    }
+
+    pub fn recipient_scan_key(&self) -> &PublicKey {
+        &self.recipient_scan_key
+    }
+
+    pub fn as_ecdh_shared_secret(&self) -> &PublicKey {
+        &self.ecdh_shared_secret
+    }
+
+    pub fn dleq_proof(&self) -> &DleqProof {
+        &self.dleq_proof
+    }
+
+    pub fn into_ecdh_shared_secret(self) -> PublicKey {
+        self.ecdh_shared_secret
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secp256k1::Secp256k1;
+    use std::str::FromStr;
+
+    #[test]
+    fn global_share_dleq_roundtrip() {
+        let secp = Secp256k1::new();
+        let private_key =
+            SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000001")
+                .unwrap();
+        let scan_priv =
+            SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000002")
+                .unwrap();
+        let recipient_scan_key = PublicKey::from_secret_key(&secp, &scan_priv);
+        let summed_input_pubkey = PublicKey::from_secret_key(&secp, &private_key);
+        let aux_rand = [3u8; 32];
+
+        let global_share = GlobalSenderEcdhShare::new_from_summed_keys(
+            &secp,
+            recipient_scan_key,
+            NonEmptyArray::new(&[NormalizedSecretKey::new(&secp, private_key, false)]).unwrap(),
+            &aux_rand,
+        )
+        .unwrap();
+
+        global_share
+            .verify_dleq_proof(&secp, NonEmptyArray::new(&[&summed_input_pubkey]).unwrap())
+            .unwrap();
+    }
+
+    #[test]
+    fn partial_share_dleq_roundtrip() {
+        let secp = Secp256k1::new();
+        let private_key =
+            SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000003")
+                .unwrap();
+        let scan_priv =
+            SecretKey::from_str("0000000000000000000000000000000000000000000000000000000000000004")
+                .unwrap();
+        let recipient_scan_key = PublicKey::from_secret_key(&secp, &scan_priv);
+        let input_pubkey = PublicKey::from_secret_key(&secp, &private_key);
+        let normalized = NormalizedSecretKey::new(&secp, private_key, false);
+        let aux_rand = [5u8; 32];
+
+        let partial =
+            PartialSenderEcdhShare::new(&secp, recipient_scan_key, 0, &normalized, &aux_rand)
+                .unwrap();
+
+        partial.verify_dleq_proof(&secp, &input_pubkey).unwrap();
+    }
 }

--- a/silentpayments/src/utils/sending.rs
+++ b/silentpayments/src/utils/sending.rs
@@ -1,11 +1,35 @@
 //! Sending utility functions.
-use crate::utils::common::{NonEmptyArray, OutPoint};
-use crate::{utils::common::SharedSecret, Error, Result};
+use crate::utils::common::{ecdh_multiply, NonEmptyArray, OutPoint, TransactionSharedSecret};
+use crate::{Error, Result};
 use secp256k1::constants::SECRET_KEY_SIZE;
-use secp256k1::ecdh::shared_secret_point;
-use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use secp256k1::{PublicKey, Secp256k1, SecretKey, Signing};
 
 use super::hash::calculate_input_hash;
+
+/// Guarantees that the secret key produces an even x-only public key when the spent output is taproot,
+/// by negating the secret key if necessary.
+#[derive(Debug, Clone)]
+pub struct NormalizedSecretKey(SecretKey);
+
+impl NormalizedSecretKey {
+    pub fn new<C: Signing>(secp: &Secp256k1<C>, secret_key: SecretKey, is_taproot: bool) -> Self {
+        let (_, parity) = secret_key.x_only_public_key(secp);
+
+        if is_taproot && parity == secp256k1::Parity::Odd {
+            return Self(secret_key.negate());
+        }
+
+        Self(secret_key)
+    }
+
+    pub fn as_inner(&self) -> &SecretKey {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> SecretKey {
+        self.0
+    }
+}
 
 /// Represents the sum of all eligible input private keys of a transaction, multiplied with the input hash.
 #[derive(Clone, Copy, Debug)]
@@ -70,14 +94,11 @@ pub fn calculate_partial_secret(
 pub fn calculate_ecdh_shared_secret(
     B_scan: &PublicKey,
     partial_secret: &PartialSecret,
-) -> SharedSecret {
-    let mut ss_bytes = [0u8; 65];
-    ss_bytes[0] = 0x04;
-
-    // Using `shared_secret_point` to ensure the multiplication is constant time
-    ss_bytes[1..].copy_from_slice(&shared_secret_point(B_scan, &partial_secret.0));
-
-    SharedSecret(PublicKey::from_slice(&ss_bytes).expect("guaranteed to be a point on the curve"))
+) -> TransactionSharedSecret {
+    TransactionSharedSecret::from_sender_ecdh(
+        ecdh_multiply(B_scan, &partial_secret.0).expect("guaranteed to be a point on the curve"),
+        *B_scan,
+    )
 }
 
 fn get_a_sum_secret_keys(input: &[(SecretKey, bool)]) -> Result<SecretKey> {
@@ -85,25 +106,18 @@ fn get_a_sum_secret_keys(input: &[(SecretKey, bool)]) -> Result<SecretKey> {
         return Err(Error::GenericError("No input provided".to_owned()));
     }
 
-    let secp = secp256k1::Secp256k1::new();
+    let secp = Secp256k1::new();
 
-    let mut negated_keys: Vec<SecretKey> = vec![];
-
-    for (key, is_taproot) in input {
-        let (_, parity) = key.x_only_public_key(&secp);
-
-        if *is_taproot && parity == secp256k1::Parity::Odd {
-            negated_keys.push(key.negate());
-        } else {
-            negated_keys.push(*key);
-        }
-    }
-
-    let (head, tail) = negated_keys.split_first().expect("input is non-empty");
-
-    let result: SecretKey = tail
+    let normalized: Vec<NormalizedSecretKey> = input
         .iter()
-        .try_fold(*head, |acc, &item| acc.add_tweak(&item.into()))?;
+        .map(|(key, is_taproot)| NormalizedSecretKey::new(&secp, *key, *is_taproot))
+        .collect();
 
-    Ok(result)
+    let (head, tail) = normalized.split_first().expect("input is non-empty");
+
+    tail.iter()
+        .try_fold(*head.as_inner(), |acc, item| {
+            acc.add_tweak(&(*item.as_inner()).into())
+        })
+        .map_err(Error::from)
 }

--- a/silentpayments/src/utils/sending.rs
+++ b/silentpayments/src/utils/sending.rs
@@ -1,24 +1,18 @@
 //! Sending utility functions.
 //!
-//! The typical flow for a single signer with DLEQ proofs is:
+//! The typical flow for a single signer is:
 //!
 //! 1. Normalize input private keys with [`NormalizedSecretKey`].
 //! 2. Create a [`GlobalSenderEcdhShare`] (single spender) or [`PartialSenderEcdhShare`]s (per input - collaborative transaction).
 //! 3. Verify BIP374 DLEQ proofs with [`PartialSenderEcdhShare::verify_dleq_proof`] /
 //!    [`GlobalSenderEcdhShare::verify_dleq_proof`].
 //! 4. Convert to a [`TransactionSharedSecret`](crate::TransactionSharedSecret), which applies the
-//!    BIP352 input hash.
-//!
-//! The legacy [`calculate_partial_secret`] / [`PartialSecret`] API remains available for callers
-//! that do not need DLEQ proofs.
+//!    BIP352 input hash, and pass to [`generate_recipient_pubkeys`](crate::sending::generate_recipient_pubkeys).
 
-use crate::utils::common::{ecdh_multiply, NonEmptyArray, OutPoint, TransactionSharedSecret};
+use crate::utils::common::{ecdh_multiply, NonEmptyArray};
 use crate::{Error, Result};
 use rust_dleq::{generate_dleq_proof, verify_dleq_proof, DleqProof};
-use secp256k1::constants::SECRET_KEY_SIZE;
 use secp256k1::{PublicKey, Secp256k1, SecretKey, Signing, Verification};
-
-use super::hash::calculate_input_hash;
 
 /// Guarantees that the secret key produces an even x-only public key when the spent output is taproot,
 /// by negating the secret key if necessary.
@@ -54,70 +48,6 @@ impl<'a> NonEmptyArray<'a, NormalizedSecretKey> {
             })
             .map_err(Error::from)
     }
-}
-
-/// Represents the sum of all eligible input private keys of a transaction, multiplied with the input hash.
-#[derive(Clone, Copy, Debug)]
-pub struct PartialSecret(pub(crate) SecretKey);
-
-impl PartialSecret {
-    /// Re-construct the partial secret from the inner bytes.
-    pub fn from_slice(data: &[u8]) -> Result<Self> {
-        Ok(Self(SecretKey::from_slice(data)?))
-    }
-
-    /// Returns the inner bytes of the partial secret
-    pub fn secret_bytes(&self) -> [u8; SECRET_KEY_SIZE] {
-        self.0.secret_bytes()
-    }
-}
-
-/// Calculate the partial secret that is needed for generating the recipient pubkeys.
-pub fn calculate_partial_secret(
-    input_keys: &[(SecretKey, bool)],
-    outpoints_data: &[OutPoint],
-) -> Result<PartialSecret> {
-    let a_sum = get_a_sum_secret_keys(input_keys)?;
-
-    let secp = Secp256k1::signing_only();
-    let A_sum = a_sum.public_key(&secp);
-
-    let outpoints = NonEmptyArray::new(outpoints_data)?;
-    let input_hash = calculate_input_hash(outpoints.min(), A_sum);
-
-    Ok(PartialSecret(a_sum.mul_tweak(&input_hash)?))
-}
-
-/// Calculate the shared secret of a transaction from a legacy partial secret.
-pub fn calculate_ecdh_shared_secret(
-    B_scan: &PublicKey,
-    partial_secret: &PartialSecret,
-) -> TransactionSharedSecret {
-    TransactionSharedSecret::from_sender_ecdh(
-        ecdh_multiply(B_scan, &partial_secret.0).expect("guaranteed to be a point on the curve"),
-        *B_scan,
-    )
-}
-
-fn get_a_sum_secret_keys(input: &[(SecretKey, bool)]) -> Result<SecretKey> {
-    if input.is_empty() {
-        return Err(Error::GenericError("No input provided".to_owned()));
-    }
-
-    let secp = Secp256k1::new();
-
-    let normalized: Vec<NormalizedSecretKey> = input
-        .iter()
-        .map(|(key, is_taproot)| NormalizedSecretKey::new(&secp, *key, *is_taproot))
-        .collect();
-
-    let (head, tail) = normalized.split_first().expect("input is non-empty");
-
-    tail.iter()
-        .try_fold(*head.as_inner(), |acc, item| {
-            acc.add_tweak(&(*item.as_inner()).into())
-        })
-        .map_err(Error::from)
 }
 
 /// ECDH share for a single eligible input: `a_i * B_scan` (before input hash).

--- a/silentpayments/tests/vector_tests.rs
+++ b/silentpayments/tests/vector_tests.rs
@@ -7,13 +7,17 @@ mod tests {
         receiving::Label,
         utils::{
             receiving::{get_pubkey_from_input, is_p2tr, PublicTweakData},
-            sending::calculate_partial_secret,
+            sending::{GlobalSenderEcdhShare, NormalizedSecretKey},
             OutPoint,
         },
-        Network, SilentPaymentAddress, SilentPaymentAddressRaw, TransactionInputs,
+        Network, NonEmptyArray, SilentPaymentAddress, SilentPaymentAddressRaw, TransactionInputs,
         TransactionSharedSecret,
     };
-    use std::{collections::HashSet, io::Cursor, str::FromStr};
+    use std::{
+        collections::{HashMap, HashSet},
+        io::Cursor,
+        str::FromStr,
+    };
 
     use silentpayments::receiving::Receiver;
 
@@ -47,25 +51,28 @@ mod tests {
         for sendingtest in test_case.sending {
             let given = sendingtest.given;
             let expected = sendingtest.expected;
-            let outpoints: Vec<OutPoint> = given
-                .vin
-                .iter()
-                .map(|vin| OutPoint::from_txid_and_vout(vin.txid.clone(), vin.vout).unwrap())
-                .collect();
             let mut input_priv_keys = Vec::new();
-            for input in given.vin {
+            let mut inputs = TransactionInputs::new();
+            for input in &given.vin {
                 let script_sig = hex::decode(&input.scriptSig).unwrap();
                 let txinwitness_bytes = hex::decode(&input.txinwitness).unwrap();
                 let mut cursor = Cursor::new(&txinwitness_bytes);
                 let txinwitness = deser_string_vector(&mut cursor).unwrap();
                 let script_pub_key = hex::decode(&input.prevout.scriptPubKey.hex).unwrap();
+                let outpoint =
+                    OutPoint::from_txid_and_vout(input.txid.clone(), input.vout).unwrap();
 
                 match get_pubkey_from_input(&script_sig, &txinwitness, &script_pub_key) {
-                    Ok(Some(_pubkey)) => input_priv_keys.push((
-                        SecretKey::from_str(&input.private_key).unwrap(),
-                        is_p2tr(&script_pub_key),
-                    )),
-                    Ok(None) => (),
+                    Ok(Some(pubkey)) => {
+                        input_priv_keys.push((
+                            SecretKey::from_str(&input.private_key).unwrap(),
+                            is_p2tr(&script_pub_key),
+                        ));
+                        inputs.push(outpoint, script_pub_key, Some(pubkey));
+                    }
+                    Ok(None) => {
+                        inputs.push(outpoint, script_pub_key, None);
+                    }
                     Err(e) => panic!("Problem parsing the input: {:?}", e),
                 }
             }
@@ -73,16 +80,41 @@ mod tests {
                 continue;
             }
 
-            // we drop the amounts from the test here, since we don't work with amounts
-            // the wallet should make sure the amount sent are correct
             let silent_addresses: Vec<SilentPaymentAddressRaw> =
                 decode_recipients(&given.recipients)
                     .into_iter()
                     .map(|addr| SilentPaymentAddressRaw::new_from_address(&addr))
                     .collect();
 
-            let partial_secret = calculate_partial_secret(&input_priv_keys, &outpoints).unwrap();
-            let outputs = generate_recipient_pubkeys(silent_addresses, partial_secret).unwrap();
+            let input_priv_keys_normalized: Vec<NormalizedSecretKey> = input_priv_keys
+                .into_iter()
+                .map(|(key, is_taproot)| NormalizedSecretKey::new(&secp, key, is_taproot))
+                .collect();
+
+            let aux_rand = [0u8; 32];
+
+            let mut shared_secrets = HashMap::new();
+            for address in &silent_addresses {
+                let recipient_scan_key = address.get_scan_pubkey();
+                if shared_secrets.contains_key(&recipient_scan_key) {
+                    continue;
+                }
+                let global_share = GlobalSenderEcdhShare::new_from_summed_keys(
+                    &secp,
+                    recipient_scan_key,
+                    NonEmptyArray::new(&input_priv_keys_normalized).unwrap(),
+                    &aux_rand,
+                )
+                .unwrap();
+                shared_secrets.insert(
+                    recipient_scan_key,
+                    TransactionSharedSecret::new_from_global_share(&secp, &global_share, &inputs)
+                        .unwrap(),
+                );
+            }
+
+            let outputs =
+                generate_recipient_pubkeys(&secp, &silent_addresses, &shared_secrets).unwrap();
 
             for output_pubkeys in &outputs {
                 for pubkey in output_pubkeys.1 {

--- a/silentpayments/tests/vector_tests.rs
+++ b/silentpayments/tests/vector_tests.rs
@@ -2,17 +2,15 @@
 mod common;
 #[cfg(test)]
 mod tests {
-    use secp256k1::{PublicKey, Scalar, Secp256k1, SecretKey};
+    use secp256k1::{Scalar, Secp256k1, SecretKey};
     use silentpayments::{
         receiving::Label,
         utils::{
-            receiving::{
-                calculate_ecdh_shared_secret, calculate_tweak_data, get_pubkey_from_input, is_p2tr,
-            },
+            receiving::{get_pubkey_from_input, is_p2tr, PublicTweakData},
             sending::calculate_partial_secret,
             OutPoint,
         },
-        Network, SilentPaymentAddress,
+        Network, SilentPaymentAddress, TransactionInputs, TransactionSharedSecret,
     };
     use std::{collections::HashSet, io::Cursor, str::FromStr};
 
@@ -78,8 +76,6 @@ mod tests {
             // the wallet should make sure the amount sent are correct
             let silent_addresses = decode_recipients(&given.recipients);
 
-            // as an alternative, we could first multiply each input priv key with the input hash
-            // that way, we never expose the sk to our library
             let partial_secret = calculate_partial_secret(&input_priv_keys, &outpoints).unwrap();
             let outputs = generate_recipient_pubkeys(silent_addresses, partial_secret).unwrap();
 
@@ -116,30 +112,29 @@ mod tests {
 
             let outputs_to_check = decode_outputs_to_check(&given.outputs);
 
-            let outpoints: Vec<OutPoint> = given
-                .vin
-                .iter()
-                .map(|vin| OutPoint::from_txid_and_vout(vin.txid.clone(), vin.vout).unwrap())
-                .collect();
-            let mut input_pub_keys = Vec::new();
+            let mut inputs = TransactionInputs::new();
             for input in given.vin {
                 let script_sig = hex::decode(&input.scriptSig).unwrap();
                 let txinwitness_bytes = hex::decode(&input.txinwitness).unwrap();
                 let mut cursor = Cursor::new(&txinwitness_bytes);
                 let txinwitness = deser_string_vector(&mut cursor).unwrap();
                 let script_pub_key = hex::decode(&input.prevout.scriptPubKey.hex).unwrap();
+                let outpoint =
+                    OutPoint::from_txid_and_vout(input.txid.clone(), input.vout).unwrap();
 
                 match get_pubkey_from_input(&script_sig, &txinwitness, &script_pub_key) {
-                    Ok(Some(pubkey)) => input_pub_keys.push(pubkey),
-                    Ok(None) => (),
+                    Ok(Some(pubkey)) => {
+                        inputs.push(outpoint, script_pub_key, Some(pubkey));
+                    }
+                    Ok(None) => {
+                        inputs.push(outpoint, script_pub_key, None);
+                    }
                     Err(e) => panic!("Problem parsing the input: {:?}", e),
                 }
             }
-            if input_pub_keys.is_empty() {
+            if inputs.input_pubkeys().iter().all(|pk| pk.is_none()) {
                 continue;
-            };
-
-            let input_pub_keys: Vec<&PublicKey> = input_pub_keys.iter().collect();
+            }
 
             for label_int in &given.labels {
                 let label = Label::new(b_scan, *label_int);
@@ -168,8 +163,10 @@ mod tests {
             // to the expected addresses
             assert_eq!(set1, set2);
 
-            let tweak_data = calculate_tweak_data(&input_pub_keys, &outpoints).unwrap();
-            let ecdh_shared_secret = calculate_ecdh_shared_secret(&tweak_data, &b_scan);
+            let tweak_data = PublicTweakData::new(&secp, &inputs).unwrap();
+            let ecdh_shared_secret =
+                TransactionSharedSecret::new_from_public_tweak_data(&secp, &tweak_data, &b_scan)
+                    .unwrap();
 
             let scanned_outputs_received = sp_receiver
                 .scan_transaction(&ecdh_shared_secret, &outputs_to_check)

--- a/silentpayments/tests/vector_tests.rs
+++ b/silentpayments/tests/vector_tests.rs
@@ -12,7 +12,7 @@ mod tests {
             sending::calculate_partial_secret,
             OutPoint,
         },
-        Network, SilentPaymentAddress,
+        Network, SilentPaymentAddress, SilentPaymentAddressRaw,
     };
     use std::{collections::HashSet, io::Cursor, str::FromStr};
 
@@ -76,7 +76,11 @@ mod tests {
 
             // we drop the amounts from the test here, since we don't work with amounts
             // the wallet should make sure the amount sent are correct
-            let silent_addresses = decode_recipients(&given.recipients);
+            let silent_addresses: Vec<SilentPaymentAddressRaw> =
+                decode_recipients(&given.recipients)
+                    .into_iter()
+                    .map(|addr| SilentPaymentAddressRaw::new_from_address(&addr))
+                    .collect();
 
             // as an alternative, we could first multiply each input priv key with the input hash
             // that way, we never expose the sk to our library

--- a/spdk-wallet/Cargo.toml
+++ b/spdk-wallet/Cargo.toml
@@ -19,6 +19,7 @@ silentpayments.workspace = true
 rayon = { workspace = true, optional = true }
 log.workspace = true
 bdk_coin_select.workspace = true
+rand = { version = "0.8", default-features = false, features = ["getrandom"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/spdk-wallet/src/client/client.rs
+++ b/spdk-wallet/src/client/client.rs
@@ -5,13 +5,12 @@ use bitcoin::{
     secp256k1::{PublicKey, Secp256k1, SecretKey},
 };
 use serde::{Deserialize, Serialize};
-use silentpayments::{Network as SpNetwork, SharedSecret, SpVersion};
 use silentpayments::{
-    SilentPaymentAddress,
-    bitcoin_hashes::sha256,
+    Network as SpNetwork, SilentPaymentAddress, SpVersion, TransactionSharedSecret,
+    bitcoin_hashes::{Hash, sha256},
     receiving::{Label, Receiver},
+    utils::receiving::PublicTweakData,
 };
-use silentpayments::{bitcoin_hashes::Hash, utils as sp_utils};
 
 use anyhow::{Error, Result};
 
@@ -80,12 +79,13 @@ impl SpClient {
     pub fn get_script_to_secret_map(
         &self,
         tweak_data_vec: Vec<PublicKey>,
-    ) -> Result<HashMap<[u8; 34], SharedSecret>> {
+    ) -> Result<HashMap<[u8; 34], TransactionSharedSecret>> {
         // if using rayon feature, import the preludes
         #[cfg(feature = "rayon")]
         use rayon::prelude::*;
 
-        let b_scan = &self.get_scan_key();
+        let secp = Secp256k1::new();
+        let b_scan = self.get_scan_key();
 
         // parallel iterator using rayon
         #[cfg(feature = "rayon")]
@@ -97,7 +97,12 @@ impl SpClient {
 
         let items: Result<Vec<_>> = tweak_data_iterator
             .map(|tweak| {
-                let secret = sp_utils::receiving::calculate_ecdh_shared_secret(&tweak, b_scan);
+                let tweak_data = PublicTweakData::new_unchecked(tweak);
+                let secret = TransactionSharedSecret::new_from_public_tweak_data(
+                    &secp,
+                    &tweak_data,
+                    &b_scan,
+                )?;
                 let spks = self.sp_receiver.get_spks_from_shared_secret(&secret)?;
 
                 Ok((secret, spks.into_values()))

--- a/spdk-wallet/src/client/spend.rs
+++ b/spdk-wallet/src/client/spend.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use anyhow::{Error, Result};
@@ -17,8 +18,11 @@ use bitcoin::{
     Amount, Network, OutPoint, ScriptBuf, Sequence, TapLeafHash, Transaction, TxIn, TxOut, Witness,
 };
 use silentpayments::Network as SpNetwork;
-use silentpayments::utils::sending::PartialSecret;
-use silentpayments::{SilentPaymentAddressRaw, utils as sp_utils};
+use silentpayments::utils::sending::{GlobalSenderEcdhShare, NormalizedSecretKey};
+use silentpayments::{
+    NonEmptyArray, SilentPaymentAddressRaw, TransactionInputs, TransactionSharedSecret,
+    utils as sp_utils,
+};
 
 use spdk_core::constants::{DATA_CARRIER_SIZE, NUMS};
 use spdk_core::updater::DiscoveredOutput;
@@ -142,12 +146,13 @@ impl SpClient {
             });
         };
 
-        let partial_secret = self.get_partial_secret_for_selected_utxos(&selected_utxos)?;
+        let shared_secrets =
+            self.build_shared_secrets_for_sp_transaction(&selected_utxos, &recipients)?;
 
         Ok(SilentPaymentUnsignedTransaction {
             selected_utxos,
             recipients,
-            partial_secret,
+            shared_secrets,
             unsigned_tx: None,
             network,
         })
@@ -240,12 +245,13 @@ impl SpClient {
             amount: Amount::from_sat(change.value),
         }];
 
-        let partial_secret = self.get_partial_secret_for_selected_utxos(&available_utxos)?;
+        let shared_secrets =
+            self.build_shared_secrets_for_sp_transaction(&available_utxos, &recipients)?;
 
         Ok(SilentPaymentUnsignedTransaction {
             selected_utxos: available_utxos,
             recipients,
-            partial_secret,
+            shared_secrets,
             unsigned_tx: None,
             network,
         })
@@ -277,9 +283,12 @@ impl SpClient {
             })
             .collect();
 
+        let secp = Secp256k1::new();
+
         let sp_address2xonlypubkeys = silentpayments::sending::generate_recipient_pubkeys(
-            sp_addresses,
-            unsigned_transaction.partial_secret,
+            &secp,
+            &sp_addresses,
+            &unsigned_transaction.shared_secrets,
         )?;
 
         let tx_outs = unsigned_transaction
@@ -437,29 +446,74 @@ impl SpClient {
         Ok(signed)
     }
 
-    pub fn get_partial_secret_for_selected_utxos(
+    fn taproot_input_pubkey(
+        script_pubkey: &ScriptBuf,
+    ) -> Result<silentpayments::secp256k1::PublicKey> {
+        use silentpayments::secp256k1::{Parity, PublicKey, XOnlyPublicKey};
+        let xonly = XOnlyPublicKey::from_slice(&script_pubkey.as_bytes()[2..])?;
+        Ok(PublicKey::from_x_only_public_key(xonly, Parity::Even))
+    }
+
+    fn sp_recipient_scan_keys(
+        recipients: &[Recipient],
+    ) -> Vec<silentpayments::secp256k1::PublicKey> {
+        let mut keys = Vec::new();
+        for recipient in recipients {
+            if let RecipientAddress::SpAddress(address) = &recipient.address {
+                let scan_key = address.get_scan_key();
+                if !keys.iter().any(|k| k == &scan_key) {
+                    keys.push(scan_key);
+                }
+            }
+        }
+        keys
+    }
+
+    fn build_shared_secrets_for_sp_transaction(
         &self,
         selected_utxos: &[(OutPoint, DiscoveredOutput)],
-    ) -> Result<PartialSecret> {
+        recipients: &[Recipient],
+    ) -> Result<HashMap<silentpayments::secp256k1::PublicKey, TransactionSharedSecret>> {
+        let recipient_scan_keys = Self::sp_recipient_scan_keys(recipients);
+        if recipient_scan_keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let secp = Secp256k1::new();
         let b_spend = self.try_get_secret_spend_key()?;
 
-        let outpoints = selected_utxos
-            .iter()
-            .map(|(outpoint, _)| {
-                Ok(sp_utils::OutPoint::from_txid_and_vout(
-                    outpoint.txid.to_string(),
-                    outpoint.vout,
-                )?)
-            })
-            .collect::<Result<Vec<sp_utils::OutPoint>>>()?;
-        let input_privkeys = selected_utxos
-            .iter()
-            .map(|(_, output)| Ok((b_spend.add_tweak(&output.tweak)?, true)))
-            .collect::<Result<Vec<_>>>()?;
+        let mut inputs = TransactionInputs::new();
+        let mut normalized_keys = Vec::with_capacity(selected_utxos.len());
+        for (outpoint, output) in selected_utxos {
+            let sp_outpoint =
+                sp_utils::OutPoint::from_txid_and_vout(outpoint.txid.to_string(), outpoint.vout)?;
+            let pubkey = Self::taproot_input_pubkey(&output.script_pubkey)?;
+            inputs.push(
+                sp_outpoint,
+                output.script_pubkey.as_bytes().to_vec(),
+                Some(pubkey),
+            );
+            let sk = b_spend.add_tweak(&output.tweak)?;
+            normalized_keys.push(NormalizedSecretKey::new(&secp, sk, true));
+        }
 
-        let partial_secret =
-            sp_utils::sending::calculate_partial_secret(&input_privkeys, &outpoints)?;
+        let mut aux_rand = [0u8; 32];
+        rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut aux_rand);
 
-        Ok(partial_secret)
+        let mut shared_secrets = HashMap::new();
+        for recipient_scan_key in recipient_scan_keys {
+            let global_share = GlobalSenderEcdhShare::new_from_summed_keys(
+                &secp,
+                recipient_scan_key,
+                NonEmptyArray::new(&normalized_keys).expect("non-empty inputs"),
+                &aux_rand,
+            )?;
+            shared_secrets.insert(
+                recipient_scan_key,
+                TransactionSharedSecret::new_from_global_share(&secp, &global_share, &inputs)?,
+            );
+        }
+
+        Ok(shared_secrets)
     }
 }

--- a/spdk-wallet/src/client/spend.rs
+++ b/spdk-wallet/src/client/spend.rs
@@ -16,9 +16,9 @@ use bitcoin::transaction::Version;
 use bitcoin::{
     Amount, Network, OutPoint, ScriptBuf, Sequence, TapLeafHash, Transaction, TxIn, TxOut, Witness,
 };
-use silentpayments::utils as sp_utils;
 use silentpayments::utils::sending::PartialSecret;
-use silentpayments::{Network as SpNetwork, SilentPaymentAddress};
+use silentpayments::Network as SpNetwork;
+use silentpayments::{SilentPaymentAddressRaw, utils as sp_utils};
 
 use spdk_core::constants::{DATA_CARRIER_SIZE, NUMS};
 use spdk_core::updater::DiscoveredOutput;
@@ -266,11 +266,13 @@ impl SpClient {
             })
             .collect();
 
-        let sp_addresses: Vec<SilentPaymentAddress> = unsigned_transaction
+        let sp_addresses: Vec<SilentPaymentAddressRaw> = unsigned_transaction
             .recipients
             .iter()
             .filter_map(|r| match &r.address {
-                RecipientAddress::SpAddress(sp_address) => Some(sp_address.to_owned()),
+                RecipientAddress::SpAddress(sp_address) => {
+                    Some(SilentPaymentAddressRaw::new_from_address(sp_address))
+                }
                 _ => None,
             })
             .collect();
@@ -287,7 +289,7 @@ impl SpClient {
                 RecipientAddress::SpAddress(s) => {
                     // We now need to fill the sp outputs with actual spk
                     let pubkeys = sp_address2xonlypubkeys
-                        .get(s)
+                        .get(&SilentPaymentAddressRaw::new_from_address(s))
                         .ok_or(Error::msg("Unknown sp address"))?;
 
                     // we currently only allow having 1 output per silent payment address

--- a/spdk-wallet/src/client/structs.rs
+++ b/spdk-wallet/src/client/structs.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use anyhow::Error;
@@ -8,7 +9,8 @@ use bitcoin::secp256k1::{PublicKey, SecretKey};
 use bitcoin::{Address, Amount, Network, OutPoint, Transaction};
 use serde::{Deserialize, Serialize};
 use silentpayments::SilentPaymentAddress;
-use silentpayments::utils::sending::PartialSecret;
+use silentpayments::TransactionSharedSecret;
+use silentpayments::secp256k1::PublicKey as SpPublicKey;
 
 use spdk_core::updater::DiscoveredOutput;
 
@@ -59,7 +61,7 @@ pub struct Recipient {
 pub struct SilentPaymentUnsignedTransaction {
     pub selected_utxos: Vec<(OutPoint, DiscoveredOutput)>,
     pub recipients: Vec<Recipient>,
-    pub partial_secret: PartialSecret,
+    pub shared_secrets: HashMap<SpPublicKey, TransactionSharedSecret>,
     pub unsigned_tx: Option<Transaction>,
     pub network: Network,
 }

--- a/spdk-wallet/src/scanner/scanner.rs
+++ b/spdk-wallet/src/scanner/scanner.rs
@@ -15,7 +15,7 @@ use bitcoin::{
 };
 use futures::{Stream, StreamExt, pin_mut};
 use log::info;
-use silentpayments::{SharedSecret, receiving::Label};
+use silentpayments::{TransactionSharedSecret, receiving::Label};
 
 use spdk_core::chain::{BlockData, ChainBackend, FilterData, UtxoData};
 use spdk_core::updater::{DiscoveredOutput, Updater};
@@ -221,7 +221,7 @@ impl<'a> SpScanner<'a> {
     async fn scan_utxos(
         &self,
         blkheight: Height,
-        secrets_map: HashMap<[u8; 34], SharedSecret>,
+        secrets_map: HashMap<[u8; 34], TransactionSharedSecret>,
     ) -> Result<Vec<(Option<Label>, UtxoData, Scalar)>> {
         let utxos = self.backend.utxos(blkheight).await?;
 


### PR DESCRIPTION
Replaces the legacy `PartialSecret` sending path with the DLEQ-aware API and migrates spdk-wallet to match.

`generate_recipient_pubkeys` now takes `SilentPaymentAddressRaw` recipients and a `HashMap<PublicKey, TransactionSharedSecret>` (one secret per scan key)
Removes `PartialSecret`, `calculate_partial_secret`, and related helpers
spdk-wallet: receiving uses `PublicTweakData` + `TransactionSharedSecret`; spending builds secrets via `GlobalSenderEcdhShare` at finalize time