### PR TITLE
refactor!: drop reverse bool scan_blocks argument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ bip321 = "0.4.0"
 bitcoin = { version = "0.32.8", features = ["serde", "rand", "base64"] }
 bitcoin_hashes = "0.13.0"
 rayon = "1.10.0"
-itertools = "0.14.0"
 futures = "0.3"
 async-trait = "0.1"
 log = "0.4"

--- a/backend-blindbit-v1/Cargo.toml
+++ b/backend-blindbit-v1/Cargo.toml
@@ -18,4 +18,3 @@ serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true
 hex.workspace = true
-itertools.workspace = true

--- a/backend-blindbit-v1/src/backend.rs
+++ b/backend-blindbit-v1/src/backend.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 use bitcoin::{Amount, absolute::Height};
 use futures::{Stream, StreamExt, stream};
 
-use itertools::Either;
 use spdk_core::chain::{BlockData, ChainBackend, SpentIndexData, UtxoData};
 
 use crate::BlindbitClient;
@@ -32,7 +31,6 @@ impl ChainBackend for BlindbitBackend {
     fn get_block_data_for_range(
         &self,
         range: RangeInclusive<Height>,
-        reverse: bool,
         dust_limit: Amount,
         with_cutthrough: bool,
     ) -> Pin<Box<dyn Stream<Item = Result<BlockData>> + Send>> {
@@ -40,11 +38,6 @@ impl ChainBackend for BlindbitBackend {
 
         // convert range to u32 since Height does not implement Step
         let range = range.start().to_consensus_u32()..=range.end().to_consensus_u32();
-
-        let range = match reverse {
-            false => Either::Left(range),
-            true => Either::Right(range.rev()),
-        };
 
         let res = stream::iter(range)
             .map(move |n| {

--- a/spdk-core/src/chain/trait.rs
+++ b/spdk-core/src/chain/trait.rs
@@ -12,7 +12,6 @@ pub trait ChainBackend {
     fn get_block_data_for_range(
         &self,
         range: RangeInclusive<Height>,
-        reverse: bool,
         dust_limit: Amount,
         with_cutthrough: bool,
     ) -> Pin<Box<dyn Stream<Item = Result<BlockData>> + Send>>;

--- a/spdk-wallet/examples/simple_scanner.rs
+++ b/spdk-wallet/examples/simple_scanner.rs
@@ -105,7 +105,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let end = Height::from_consensus(SCAN_END_HEIGHT)?;
 
     scanner
-        .scan_blocks(start..=end, false, DUST_LIMIT, WITH_CUTTHROUGH)
+        .scan_blocks(start..=end, DUST_LIMIT, WITH_CUTTHROUGH)
         .await?;
 
     // print all received updates

--- a/spdk-wallet/src/scanner/scanner.rs
+++ b/spdk-wallet/src/scanner/scanner.rs
@@ -50,22 +50,20 @@ impl<'a> SpScanner<'a> {
     pub async fn scan_blocks(
         &mut self,
         range: RangeInclusive<Height>,
-        reverse: bool,
         dust_limit: Amount,
         with_cutthrough: bool,
     ) -> Result<()> {
         info!(
-            "start: {} end: {}, reverse: {}",
+            "start: {} end: {}",
             range.start().to_consensus_u32(),
             range.end().to_consensus_u32(),
-            reverse,
         );
         let start_time: Instant = Instant::now();
 
         // get block data stream
         let block_data_stream =
             self.backend
-                .get_block_data_for_range(range, reverse, dust_limit, with_cutthrough);
+                .get_block_data_for_range(range, dust_limit, with_cutthrough);
 
         // process blocks using block data stream
         self.process_blocks(block_data_stream).await?;

--- a/spdk-wallet/tests/mock/chain.rs
+++ b/spdk-wallet/tests/mock/chain.rs
@@ -17,7 +17,6 @@ impl ChainBackend for MockChainBackend {
     fn get_block_data_for_range(
         &self,
         range: RangeInclusive<Height>,
-        _reverse: bool,
         _dust_limit: Amount,
         _with_cutthrough: bool,
     ) -> Pin<Box<dyn Stream<Item = Result<BlockData>> + Send>> {

--- a/spdk-wallet/tests/test.rs
+++ b/spdk-wallet/tests/test.rs
@@ -47,7 +47,7 @@ async fn simple_scan_single_block() {
         .unwrap();
 
     scanner
-        .scan_blocks(block_height..=block_height, false, DUST_LIMIT, true)
+        .scan_blocks(block_height..=block_height, DUST_LIMIT, true)
         .await
         .unwrap();
 
@@ -102,12 +102,7 @@ async fn simple_scan_multiple_blocks() {
             .unwrap();
 
     scanner
-        .scan_blocks(
-            first_block_height..=second_block_height,
-            false,
-            DUST_LIMIT,
-            true,
-        )
+        .scan_blocks(first_block_height..=second_block_height, DUST_LIMIT, true)
         .await
         .unwrap();
 
@@ -174,7 +169,7 @@ async fn scan_single_block_with_output() {
     let block_height = Height::from_consensus(295125).unwrap();
 
     scanner
-        .scan_blocks(block_height..=block_height, false, DUST_LIMIT, true)
+        .scan_blocks(block_height..=block_height, DUST_LIMIT, true)
         .await
         .unwrap();
 
@@ -232,7 +227,7 @@ async fn scan_single_block_with_spent_input() {
     let block_height = Height::from_consensus(295147).unwrap();
 
     scanner
-        .scan_blocks(block_height..=block_height, false, DUST_LIMIT, true)
+        .scan_blocks(block_height..=block_height, DUST_LIMIT, true)
         .await
         .unwrap();
 


### PR DESCRIPTION
We decided not to pursue the 'scanning in reverse' approach, so drop support for this flag.