### PR TITLE
refactor: rename SilentPaymentAddressDisplay -> EncodedSilentPaymentAddress

### DIFF
--- a/silentpayments/README.md
+++ b/silentpayments/README.md
@@ -19,7 +19,7 @@ The library is split up in two parts: sending and receiving.
 This library offers granular feature flags to minimize dependencies for different use cases:
 
 - **default**: Enables all features (`encode`, `sending`, `receiving`)
-- **encode**: Enables string encoding/decoding for `SilentPaymentAddressDisplay` (adds `bech32` dependency)
+- **encode**: Adds `EncodedSilentPaymentAddress` struct, a helper struct for string encoding/decoding (adds `bech32` dependency)
 - **serde**: Enables serde serialization/deserialization for types (adds `serde` dependency)
 - **sending**: Enables sending functionality (adds `bitcoin_hashes`, `hex` dependencies)
 - **receiving**: Enables receiving functionality (adds `bitcoin_hashes`, `hex`, `bimap`, `serde` dependencies)
@@ -35,7 +35,7 @@ silentpayments = { version = "0.4", default-features = false }
 
 This configuration only pulls in `secp256k1` as a dependency, significantly reducing the dependency tree for applications that only need to work with silent payment addresses without implementing the full protocol.
 
-**Bring Your Own Parser**: Even without the `encode` feature, you can construct a `SilentPaymentAddress` using `SilentPaymentAddress::new()` from pubkeys you parsed yourself. With `encode`, use `SilentPaymentAddressDisplay` for bech32m strings; see `SilentPaymentAddressDisplay::new` for the on-wire format if you parse bech32 yourself.
+**Bring Your Own Parser**: Even without the `encode` feature, you can construct a `SilentPaymentAddress` using `SilentPaymentAddress::new()` from pubkeys you parsed yourself. With `encode`, use `EncodedSilentPaymentAddress` for bech32m strings; see `EncodedSilentPaymentAddress::new` for the on-wire format if you parse bech32 yourself.
 
 ### Custom Feature Combinations
 

--- a/silentpayments/src/lib.rs
+++ b/silentpayments/src/lib.rs
@@ -6,7 +6,7 @@
 //! This library offers granular feature flags to minimize dependencies:
 //!
 //! - **default**: Enables `encode`, `sending`, and `receiving` features
-//! - **encode**: Enables string encoding/decoding for `SilentPaymentAddressDisplay` (requires `bech32`)
+//! - **encode**: Adds `EncodedSilentPaymentAddress` struct, a helper struct for string encoding/decoding (requires `bech32`)
 //! - **serde**: Enables serde serialization/deserialization for types
 //! - **sending**: Enables sending functionality (requires `bitcoin_hashes`, `hex`, and `encode`)
 //! - **receiving**: Enables receiving functionality (requires `bitcoin_hashes`, `hex`, `bimap`, `serde`, and `encode`)
@@ -26,7 +26,7 @@
 //!
 //! **Note**: Without the `encode` feature, construct a [`SilentPaymentAddress`] from
 //! parsed pubkeys using [`SilentPaymentAddress::new`]. With `encode`, use
-//! [`SilentPaymentAddressDisplay`] for bech32m strings (see [`SilentPaymentAddressDisplay::new`]
+//! [`EncodedSilentPaymentAddress`] for bech32m strings (see [`EncodedSilentPaymentAddress::new`]
 //! for the on-wire format if you parse bech32 yourself).
 //!
 //! ## Examples
@@ -51,12 +51,12 @@ pub use bitcoin_hashes;
 pub use secp256k1;
 
 pub use crate::error::Error;
+#[cfg(feature = "encode")]
+pub use utils::common::EncodedSilentPaymentAddress;
 pub use utils::common::Network;
 #[cfg(any(feature = "sending", feature = "receiving"))]
 pub use utils::common::SharedSecret;
 pub use utils::common::SilentPaymentAddress;
-#[cfg(feature = "encode")]
-pub use utils::common::SilentPaymentAddressDisplay;
 pub use utils::common::SpVersion;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/silentpayments/src/utils/common.rs
+++ b/silentpayments/src/utils/common.rs
@@ -159,7 +159,7 @@ impl TryFrom<u8> for SpVersion {
 /// (`B_spend + m·G`).
 #[cfg_attr(
     feature = "encode",
-    doc = "\n\nNetwork is only needed for bech32m strings; use [`SilentPaymentAddressDisplay`] or [`SilentPaymentAddress::to_display_for_network`] when encoding or showing an address."
+    doc = "\n\nNetwork is only needed for bech32m strings; use [`EncodedSilentPaymentAddress`] or [`SilentPaymentAddress::to_display_for_network`] when encoding or showing an address."
 )]
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct SilentPaymentAddress {
@@ -188,9 +188,9 @@ impl SilentPaymentAddress {
     }
 
     #[cfg(feature = "encode")]
-    /// Attach a [`Network`] for string encoding via [`SilentPaymentAddressDisplay`].
-    pub fn to_display_for_network(&self, network: Network) -> SilentPaymentAddressDisplay {
-        SilentPaymentAddressDisplay::from_sp_address(*self, network)
+    /// Attach a [`Network`] for string encoding via [`EncodedSilentPaymentAddress`].
+    pub fn to_display_for_network(&self, network: Network) -> EncodedSilentPaymentAddress {
+        EncodedSilentPaymentAddress::from_sp_address(*self, network)
     }
 
     pub fn try_from_byte_array_v0(bytes: &[u8; PUBLIC_KEY_SIZE * 2]) -> Result<Self> {
@@ -216,15 +216,15 @@ impl SilentPaymentAddress {
 }
 
 #[cfg(feature = "encode")]
-impl From<SilentPaymentAddressDisplay> for SilentPaymentAddress {
-    fn from(value: SilentPaymentAddressDisplay) -> Self {
+impl From<EncodedSilentPaymentAddress> for SilentPaymentAddress {
+    fn from(value: EncodedSilentPaymentAddress) -> Self {
         value.sp_address
     }
 }
 
 #[cfg(feature = "encode")]
-impl From<&SilentPaymentAddressDisplay> for SilentPaymentAddress {
-    fn from(value: &SilentPaymentAddressDisplay) -> Self {
+impl From<&EncodedSilentPaymentAddress> for SilentPaymentAddress {
+    fn from(value: &EncodedSilentPaymentAddress) -> Self {
         value.sp_address
     }
 }
@@ -232,13 +232,13 @@ impl From<&SilentPaymentAddressDisplay> for SilentPaymentAddress {
 /// A silent payment address with network, serializable as a bech32m string.
 #[cfg(feature = "encode")]
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-pub struct SilentPaymentAddressDisplay {
+pub struct EncodedSilentPaymentAddress {
     sp_address: SilentPaymentAddress,
     network: Network,
 }
 
 #[cfg(feature = "serde")]
-impl Serialize for SilentPaymentAddressDisplay {
+impl Serialize for EncodedSilentPaymentAddress {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -249,7 +249,7 @@ impl Serialize for SilentPaymentAddressDisplay {
 }
 
 #[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for SilentPaymentAddressDisplay {
+impl<'de> Deserialize<'de> for EncodedSilentPaymentAddress {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -261,7 +261,7 @@ impl<'de> Deserialize<'de> for SilentPaymentAddressDisplay {
 }
 
 #[cfg(feature = "encode")]
-impl SilentPaymentAddressDisplay {
+impl EncodedSilentPaymentAddress {
     /// Build a display address from an existing [`SilentPaymentAddress`] and [`Network`].
     pub fn from_sp_address(sp_address: SilentPaymentAddress, network: Network) -> Self {
         Self {
@@ -270,7 +270,7 @@ impl SilentPaymentAddressDisplay {
         }
     }
 
-    /// Construct a [`SilentPaymentAddressDisplay`] from its component parts.
+    /// Construct a [`EncodedSilentPaymentAddress`] from its component parts.
     ///
     /// Combines a [`SilentPaymentAddress`] with a [`Network`] for bech32m string
     /// encoding. If you already have a [`SilentPaymentAddress`], prefer
@@ -294,13 +294,13 @@ impl SilentPaymentAddressDisplay {
     ///
     /// ```ignore
     /// use secp256k1::PublicKey;
-    /// use silentpayments::{Network, SilentPaymentAddressDisplay, SpVersion};
+    /// use silentpayments::{Network, EncodedSilentPaymentAddress, SpVersion};
     ///
     /// // After parsing bech32 yourself and extracting the pubkeys:
     /// let scan_key = PublicKey::from_slice(&scan_bytes)?;
     /// let m_pubkey = PublicKey::from_slice(&m_pubkey_bytes)?;
     ///
-    /// let display = SilentPaymentAddressDisplay::new(
+    /// let display = EncodedSilentPaymentAddress::new(
     ///     scan_key,
     ///     m_pubkey,
     ///     Network::Mainnet,
@@ -356,14 +356,14 @@ impl SilentPaymentAddressDisplay {
 }
 
 #[cfg(feature = "encode")]
-impl fmt::Display for SilentPaymentAddressDisplay {
+impl fmt::Display for EncodedSilentPaymentAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", <Self as Into<String>>::into(*self))
     }
 }
 
 #[cfg(feature = "encode")]
-impl TryFrom<&str> for SilentPaymentAddressDisplay {
+impl TryFrom<&str> for EncodedSilentPaymentAddress {
     type Error = Error;
 
     fn try_from(addr: &str) -> Result<Self> {
@@ -400,7 +400,7 @@ impl TryFrom<&str> for SilentPaymentAddressDisplay {
 }
 
 #[cfg(feature = "encode")]
-impl TryFrom<String> for SilentPaymentAddressDisplay {
+impl TryFrom<String> for EncodedSilentPaymentAddress {
     type Error = Error;
 
     fn try_from(addr: String) -> Result<Self> {
@@ -409,8 +409,8 @@ impl TryFrom<String> for SilentPaymentAddressDisplay {
 }
 
 #[cfg(feature = "encode")]
-impl From<SilentPaymentAddressDisplay> for String {
-    fn from(val: SilentPaymentAddressDisplay) -> Self {
+impl From<EncodedSilentPaymentAddress> for String {
+    fn from(val: EncodedSilentPaymentAddress) -> Self {
         let hrp = match val.network {
             Network::Testnet => "tsp",
             Network::Regtest => "sprt",

--- a/silentpayments/tests/common/structs.rs
+++ b/silentpayments/tests/common/structs.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 use serde::Deserialize;
-use silentpayments::SilentPaymentAddressDisplay;
+use silentpayments::EncodedSilentPaymentAddress;
 
 #[derive(Debug, Deserialize)]
 pub struct TestData {
@@ -50,7 +50,7 @@ pub struct ReceivingDataGiven {
 
 #[derive(Debug, Deserialize)]
 pub struct ReceivingDataExpected {
-    pub addresses: Vec<SilentPaymentAddressDisplay>,
+    pub addresses: Vec<EncodedSilentPaymentAddress>,
     pub outputs: Vec<OutputWithSignature>,
 }
 

--- a/silentpayments/tests/common/utils.rs
+++ b/silentpayments/tests/common/utils.rs
@@ -3,7 +3,7 @@ use std::{fs::File, io::Read, str::FromStr};
 use bitcoin_hashes::Hash;
 use secp256k1::{Message, Scalar, SecretKey, XOnlyPublicKey};
 use serde_json::from_str;
-use silentpayments::{SilentPaymentAddress, SilentPaymentAddressDisplay};
+use silentpayments::{EncodedSilentPaymentAddress, SilentPaymentAddress};
 
 use super::structs::{OutputWithSignature, TestData};
 
@@ -67,7 +67,7 @@ pub fn decode_recipients(recipients: &[String]) -> Vec<SilentPaymentAddress> {
     recipients
         .iter()
         .map(|sp_addr_str| {
-            let display: SilentPaymentAddressDisplay = sp_addr_str.as_str().try_into().unwrap();
+            let display: EncodedSilentPaymentAddress = sp_addr_str.as_str().try_into().unwrap();
             SilentPaymentAddress::from(display)
         })
         .collect()

--- a/spdk-wallet/src/client/bip321_parsing.rs
+++ b/spdk-wallet/src/client/bip321_parsing.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use bip321::{Bip321Error, ExtensionHandler, FieldWithAttributes};
-use silentpayments::{Network, SilentPaymentAddressDisplay};
+use silentpayments::{EncodedSilentPaymentAddress, Network};
 
 /// Error returned when validating silent payment fields of a BIP 321 URI.
 #[derive(Debug)]
@@ -102,11 +102,11 @@ impl ExtensionHandler for SpUriExtension {
 fn parse_slot(
     fields: &[FieldWithAttributes<String>],
     expected: Network,
-) -> Result<Vec<SilentPaymentAddressDisplay>, SpUriParseError> {
+) -> Result<Vec<EncodedSilentPaymentAddress>, SpUriParseError> {
     fields
         .iter()
         .map(|field| {
-            let addr = SilentPaymentAddressDisplay::try_from(field.inner().as_str())
+            let addr = EncodedSilentPaymentAddress::try_from(field.inner().as_str())
                 .map_err(SpUriParseError::Address)?;
             let got = addr.network();
             let ok = match expected {
@@ -127,7 +127,7 @@ fn parse_slot(
 /// every entry is parsed. Each address must be mainnet.
 pub fn parse_sp(
     fields: &[FieldWithAttributes<String>],
-) -> Result<Vec<SilentPaymentAddressDisplay>, SpUriParseError> {
+) -> Result<Vec<EncodedSilentPaymentAddress>, SpUriParseError> {
     parse_slot(fields, Network::Mainnet)
 }
 
@@ -138,7 +138,7 @@ pub fn parse_sp(
 /// regtest), matching bip321's `tb` rule.
 pub fn parse_tsp(
     fields: &[FieldWithAttributes<String>],
-) -> Result<Vec<SilentPaymentAddressDisplay>, SpUriParseError> {
+) -> Result<Vec<EncodedSilentPaymentAddress>, SpUriParseError> {
     parse_slot(fields, Network::Testnet)
 }
 
@@ -151,10 +151,10 @@ mod tests {
     use silentpayments::SpVersion;
 
     use super::{
-        Network, SilentPaymentAddressDisplay, SpUriExtension, SpUriParseError, parse_sp, parse_tsp,
+        EncodedSilentPaymentAddress, Network, SpUriExtension, SpUriParseError, parse_sp, parse_tsp,
     };
 
-    fn make_sp_address(network: Network) -> SilentPaymentAddressDisplay {
+    fn make_sp_address(network: Network) -> EncodedSilentPaymentAddress {
         let secp = Secp256k1::new();
         let (scan_bytes, spend_bytes) = match network {
             Network::Mainnet => ([0x03; 32], [0x04; 32]),
@@ -167,7 +167,7 @@ mod tests {
         let spend = SecretKey::from_slice(&spend_bytes)
             .unwrap()
             .public_key(&secp);
-        SilentPaymentAddressDisplay::new(scan, spend, network, SpVersion::ZERO)
+        EncodedSilentPaymentAddress::new(scan, spend, network, SpVersion::ZERO)
     }
 
     fn parse(s: &str) -> Bip321Uri<SpUriExtension> {

--- a/spdk-wallet/src/client/spend.rs
+++ b/spdk-wallet/src/client/spend.rs
@@ -18,7 +18,7 @@ use bitcoin::{
 };
 use silentpayments::utils as sp_utils;
 use silentpayments::utils::sending::PartialSecret;
-use silentpayments::{Network as SpNetwork, SilentPaymentAddress, SilentPaymentAddressDisplay};
+use silentpayments::{EncodedSilentPaymentAddress, Network as SpNetwork, SilentPaymentAddress};
 
 use spdk_core::constants::{DATA_CARRIER_SIZE, NUMS};
 use spdk_core::updater::DiscoveredOutput;
@@ -135,7 +135,7 @@ impl SpClient {
         let change = coin_selector.drain(target, change_policy);
         let change_value = if change.is_some() { change.value } else { 0 };
         if change_value > 0 {
-            let change_address = SilentPaymentAddressDisplay::from_sp_address(
+            let change_address = EncodedSilentPaymentAddress::from_sp_address(
                 self.sp_receiver.get_change_address(),
                 address_sp_network,
             );

--- a/spdk-wallet/src/client/structs.rs
+++ b/spdk-wallet/src/client/structs.rs
@@ -7,7 +7,7 @@ use bitcoin::key::Secp256k1;
 use bitcoin::secp256k1::{PublicKey, SecretKey};
 use bitcoin::{Address, Amount, Network, OutPoint, Transaction};
 use serde::{Deserialize, Serialize};
-use silentpayments::SilentPaymentAddressDisplay;
+use silentpayments::EncodedSilentPaymentAddress;
 use silentpayments::utils::sending::PartialSecret;
 
 use spdk_core::updater::DiscoveredOutput;
@@ -19,14 +19,14 @@ pub use bdk_coin_select::FeeRate;
 #[serde(untagged)]
 pub enum RecipientAddress {
     LegacyAddress(Address<NetworkUnchecked>),
-    SpAddress(SilentPaymentAddressDisplay),
+    SpAddress(EncodedSilentPaymentAddress),
     Data(Vec<u8>), // OpReturn output
 }
 
 impl TryFrom<String> for RecipientAddress {
     type Error = anyhow::Error;
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        if let Ok(sp_address) = SilentPaymentAddressDisplay::try_from(value.as_str()) {
+        if let Ok(sp_address) = EncodedSilentPaymentAddress::try_from(value.as_str()) {
             Ok(Self::SpAddress(sp_address))
         } else if let Ok(legacy_address) = Address::from_str(&value) {
             Ok(Self::LegacyAddress(legacy_address))


### PR DESCRIPTION
Since this struct is mainly used for encoding/decoding purposes, I think this name is more appropriate.