### PR TITLE
refactor: drop get_ prefix from wallet accessors

### DIFF
--- a/silentpayments/src/receiving.rs
+++ b/silentpayments/src/receiving.rs
@@ -444,7 +444,7 @@ impl Receiver {
     /// This function will return an error if:
     ///
     /// * An error occurs during elliptic curve computation. This may happen if a sender is being malicious.
-    pub fn get_spks_from_shared_secret(
+    pub fn script_pubkeys_from_shared_secret(
         &self,
         ecdh_shared_secret: &SharedSecret,
     ) -> Result<HashMap<Option<Label>, [u8; 34]>> {

--- a/spdk-wallet/src/client/client.rs
+++ b/spdk-wallet/src/client/client.rs
@@ -57,26 +57,26 @@ impl SpClient {
         self.sp_receiver.receiving_code()
     }
 
-    pub fn get_scan_key(&self) -> SecretKey {
+    pub fn scan_key(&self) -> SecretKey {
         self.scan_sk
     }
 
-    pub fn get_spend_key(&self) -> SpendKey {
+    pub fn spend_key(&self) -> SpendKey {
         self.spend_key.clone()
     }
 
-    pub fn get_network(&self) -> Network {
+    pub fn network(&self) -> Network {
         self.network
     }
 
-    pub fn try_get_secret_spend_key(&self) -> Result<SecretKey> {
+    pub fn try_secret_spend_key(&self) -> Result<SecretKey> {
         match self.spend_key {
             SpendKey::Public(_) => Err(Error::msg("Don't have secret key")),
             SpendKey::Secret(sk) => Ok(sk),
         }
     }
 
-    pub fn get_script_to_secret_map(
+    pub fn script_to_secret_map(
         &self,
         tweak_data_vec: Vec<PublicKey>,
     ) -> Result<HashMap<[u8; 34], SharedSecret>> {
@@ -84,7 +84,7 @@ impl SpClient {
         #[cfg(feature = "rayon")]
         use rayon::prelude::*;
 
-        let b_scan = &self.get_scan_key();
+        let b_scan = &self.scan_key();
 
         // parallel iterator using rayon
         #[cfg(feature = "rayon")]
@@ -97,7 +97,7 @@ impl SpClient {
         let items: Result<Vec<_>> = tweak_data_iterator
             .map(|tweak| {
                 let secret = sp_utils::receiving::calculate_ecdh_shared_secret(&tweak, b_scan);
-                let spks = self.sp_receiver.get_spks_from_shared_secret(&secret)?;
+                let spks = self.sp_receiver.script_pubkeys_from_shared_secret(&secret)?;
 
                 Ok((secret, spks.into_values()))
             })
@@ -112,7 +112,7 @@ impl SpClient {
         Ok(res)
     }
 
-    pub fn get_client_fingerprint(&self) -> Result<[u8; 8]> {
+    pub fn client_fingerprint(&self) -> Result<[u8; 8]> {
         let sp_code: SilentPaymentCode = self.receiving_code();
         let scan_pk = sp_code.scan_key();
         let spend_pk = sp_code.m_pubkey();

--- a/spdk-wallet/src/client/spend.rs
+++ b/spdk-wallet/src/client/spend.rs
@@ -141,7 +141,7 @@ impl SpClient {
             });
         };
 
-        let partial_secret = self.get_partial_secret_for_selected_utxos(&selected_utxos)?;
+        let partial_secret = self.partial_secret_for_selected_utxos(&selected_utxos)?;
 
         Ok(SilentPaymentUnsignedTransaction {
             selected_utxos,
@@ -239,7 +239,7 @@ impl SpClient {
             amount: Amount::from_sat(change.value),
         }];
 
-        let partial_secret = self.get_partial_secret_for_selected_utxos(&available_utxos)?;
+        let partial_secret = self.partial_secret_for_selected_utxos(&available_utxos)?;
 
         Ok(SilentPaymentUnsignedTransaction {
             selected_utxos: available_utxos,
@@ -375,7 +375,7 @@ impl SpClient {
         aux_rand: &[u8; 32],
     ) -> Result<Transaction> {
         // TODO check that we have aux_rand, at least that it's not all `0`s
-        let b_spend = self.try_get_secret_spend_key()?;
+        let b_spend = self.try_secret_spend_key()?;
 
         let to_sign = match unsigned_tx.unsigned_tx.as_ref() {
             Some(tx) => tx,
@@ -434,11 +434,11 @@ impl SpClient {
         Ok(signed)
     }
 
-    pub fn get_partial_secret_for_selected_utxos(
+    pub fn partial_secret_for_selected_utxos(
         &self,
         selected_utxos: &[(OutPoint, DiscoveredOutput)],
     ) -> Result<PartialSecret> {
-        let b_spend = self.try_get_secret_spend_key()?;
+        let b_spend = self.try_secret_spend_key()?;
 
         let outpoints = selected_utxos
             .iter()

--- a/spdk-wallet/src/scanner/scanner.rs
+++ b/spdk-wallet/src/scanner/scanner.rs
@@ -148,7 +148,7 @@ impl<'a> SpScanner<'a> {
         let mut res = HashMap::new();
 
         if !tweaks.is_empty() {
-            let secrets_map = self.client.get_script_to_secret_map(tweaks)?;
+            let secrets_map = self.client.script_to_secret_map(tweaks)?;
 
             //last_scan = last_scan.max(n as u32);
             let candidate_spks: Vec<&[u8; 34]> = secrets_map.keys().collect();


### PR DESCRIPTION
Rename SpClient getters to follow Rust naming conventions, and rename `Receiver::get_spks_from_shared_secret` to `script_pubkeys_from_shared_secret`.