### PR TITLE
fix(spdk-wallet): erase secret key material on drop

### DIFF
--- a/spdk-wallet/src/client/client.rs
+++ b/spdk-wallet/src/client/client.rs
@@ -132,3 +132,11 @@ impl SpClient {
         Ok(wallet_fingerprint)
     }
 }
+
+impl Drop for SpClient {
+    fn drop(&mut self) {
+        // Erase the scan key before dropping; the spend key is erased
+        // by SpendKey's own Drop impl.
+        self.scan_sk.non_secure_erase();
+    }
+}

--- a/spdk-wallet/src/client/structs.rs
+++ b/spdk-wallet/src/client/structs.rs
@@ -70,6 +70,18 @@ pub enum SpendKey {
     Public(PublicKey),
 }
 
+impl Drop for SpendKey {
+    fn drop(&mut self) {
+        if let Self::Secret(sk) = self {
+            // Erase the key material before dropping.
+            // secp256k1::SecretKey does not implement Zeroize (its inner
+            // array is private); non_secure_erase() is the zeroize-documented
+            // erase path (volatile C-level memset, cannot be optimized away).
+            sk.non_secure_erase();
+        }
+    }
+}
+
 impl TryInto<SecretKey> for SpendKey {
     type Error = anyhow::Error;
     fn try_into(self) -> std::prelude::v1::Result<SecretKey, Error> {


### PR DESCRIPTION
Add Drop impls that erase secret key material before it dies:
- SpClient::drop erases scan_sk; SpendKey::drop erases the Secret variant.
- Uses secp256k1 SecretKey::non_secure_erase(): zeroize-documented volatile write + SeqCst compiler fence (no optimizer elision), overwrites with a valid dummy keypair. No unsafe in our code, no layout assumptions on the foreign type (its inner array is private, so it cannot implement Zeroize).